### PR TITLE
chore: global button element with variants

### DIFF
--- a/lib/presentation/common/transaction_stepper/view/transaction_stepper.dart
+++ b/lib/presentation/common/transaction_stepper/view/transaction_stepper.dart
@@ -274,15 +274,11 @@ class TransactionStepperState<T, R> extends State<TransactionStepper<T, R>> {
                       child: Row(
                         children: [
                           Expanded(
-                            child: SizedBox(
-                              height: 64,
-                              child: HorizonOutlinedButton(
-                                isTransparent: false,
+                              child: HorizonButton(
                                 onPressed: _handleNext,
                                 buttonText: TransactionStepper
                                     .defaultButtonTexts[_currentStep],
                               ),
-                            ),
                           ),
                         ],
                       ),

--- a/lib/presentation/screens/horizon/redesign_ui.dart
+++ b/lib/presentation/screens/horizon/redesign_ui.dart
@@ -569,7 +569,7 @@ class _HorizonRedesignDropdownState<T>
             height: double.infinity,
             color: Colors.transparent,
             child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+              filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
               child: Container(
                 color: transparentBlack33,
                 child: Column(
@@ -606,15 +606,12 @@ class _HorizonRedesignDropdownState<T>
                                       horizontal: 12,
                                       vertical: 21,
                                     ),
-                                    child: Row(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.spaceBetween,
-                                      children: [
-                                        DefaultTextStyle(
-                                          style: theme.dropdownMenuTheme.textStyle!,
-                                          child: item.child,
-                                        ),
-                                      ],
+                                    child: SizedBox(
+                                      width: double.infinity,
+                                      child: DefaultTextStyle(
+                                        style: theme.dropdownMenuTheme.textStyle!,
+                                        child: item.child,
+                                      ),
                                     ),
                                   ),
                                 ),

--- a/lib/presentation/screens/horizon/redesign_ui.dart
+++ b/lib/presentation/screens/horizon/redesign_ui.dart
@@ -7,6 +7,233 @@ import 'package:horizon/presentation/common/theme_extension.dart';
 import 'package:horizon/utils/app_icons.dart';
 
 Widget commonHeightSizedBox = const SizedBox(height: 10);
+const double defaultButtonHeight = 54;
+
+enum ButtonVariant { black, green, gradient }
+
+class GradientContainer extends StatelessWidget {
+  final bool isHovered;
+  final Widget child;
+  final BoxDecoration? decoration;
+  const GradientContainer({
+    super.key,
+    required this.child,
+    this.isHovered = false,
+    this.decoration,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final colors = isHovered
+        ? brightness == Brightness.dark
+            ? const [
+                Color.fromRGBO(223, 217, 191, 0.50),
+                Color.fromRGBO(238, 208, 154, 0.50),
+                Color.fromRGBO(238, 179, 149, 0.50),
+                Color.fromRGBO(210, 166, 176, 0.50),
+              ]
+            : const [
+                Color(0xFF563A8E),
+                Color(0xFF306E94),
+              ]
+        : brightness == Brightness.dark
+            ? const [
+                goldenGradient1,
+                yellow1,
+                goldenGradient2,
+                goldenGradient3,
+              ]
+            : const [
+                duskGradient2,
+                duskGradient1,
+              ];
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: colors,
+        ),
+        borderRadius: decoration?.borderRadius,
+        border: decoration?.border,
+        boxShadow: decoration?.boxShadow,
+        color: decoration?.color,
+        image: decoration?.image,
+        shape: decoration?.shape ?? BoxShape.rectangle,
+      ),
+      child: child,
+    );
+  }
+}
+
+class HorizonButton extends StatefulWidget {
+  final String buttonText;
+  final VoidCallback? onPressed;
+  final ButtonVariant variant;
+  final double? width;
+  final double? height;
+  final bool disabled;
+  final Widget? child;
+  final Icon? icon;
+
+  const HorizonButton({
+    super.key,
+    required this.buttonText,
+    required this.onPressed,
+    this.width = double.infinity,
+    this.height = defaultButtonHeight,
+    this.variant = ButtonVariant.green,
+    this.disabled = false,
+    this.child,
+    this.icon,
+  });
+
+  @override
+  State<HorizonButton> createState() => _HorizonButtonState();
+}
+
+class _HorizonButtonState extends State<HorizonButton> {
+  bool isHovered = false;
+  @override
+  Widget build(BuildContext context) {
+    ButtonStyle style = ElevatedButton.styleFrom(
+      backgroundColor: green2,
+      foregroundColor: offBlack,
+    );
+
+    TextStyle textStyle = TextStyle(
+        color: style.foregroundColor?.resolve({}),
+        fontSize: 16,
+        fontWeight: FontWeight.w500);
+
+    BoxBorder? border;
+
+    BoxShadow boxShadow = const BoxShadow(
+      color: Color.fromRGBO(255, 255, 255, 0.2),
+      blurRadius: 10,
+      offset: Offset(0, 0),
+    );
+
+    switch (widget.variant) {
+      case ButtonVariant.black:
+        style = style.copyWith(
+          backgroundColor: WidgetStateProperty.all(black),
+          foregroundColor: WidgetStateProperty.all(offWhite),
+        );
+        textStyle = textStyle.copyWith(
+          color: offWhite,
+        );
+        border = Border.all(color: transparentWhite8, width: 1);
+        boxShadow = const BoxShadow(
+          color: Color.fromRGBO(255, 255, 255, 0.1),
+          blurRadius: 10,
+          offset: Offset(0, 0),
+        );
+      case ButtonVariant.green:
+        style = style.copyWith(
+          backgroundColor: WidgetStateProperty.all(green2),
+          foregroundColor: WidgetStateProperty.all(offBlack),
+        );
+        style = style.copyWith(
+          overlayColor: WidgetStateProperty.resolveWith<Color?>(
+            (Set<WidgetState> states) {
+              if (states.contains(WidgetState.pressed) ||
+                  states.contains(WidgetState.hovered)) {
+                return const Color.fromARGB(255, 23, 183, 156);
+              }
+              return null;
+            },
+          ),
+        );
+      case ButtonVariant.gradient:
+        style = style.copyWith(
+          backgroundColor: WidgetStateProperty.all(Colors.transparent),
+          foregroundColor: WidgetStateProperty.all(offBlack),
+        );
+    }
+
+    if (widget.disabled) {
+      style = style.copyWith(
+        backgroundColor: WidgetStateProperty.all(
+          const Color.fromRGBO(254, 251, 249, 0.16),
+        ),
+      );
+
+      textStyle = textStyle.copyWith(
+        color: const Color.fromRGBO(254, 251, 249, 0.16),
+      );
+    }
+
+    if (widget.variant == ButtonVariant.gradient) {
+      return SizedBox(
+        width: widget.width,
+        height: widget.height,
+        child: GradientContainer(
+          isHovered: isHovered,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(50),
+            boxShadow: isHovered
+                ? [
+                    boxShadow,
+                  ]
+                : null,
+          ),
+          child: ElevatedButton(
+            onPressed: widget.disabled ? null : widget.onPressed,
+            onHover: (value) => setState(() => isHovered = value),
+            style: style.copyWith(
+              minimumSize: WidgetStateProperty.all(
+                  Size.fromHeight(widget.height ?? defaultButtonHeight)),
+              padding: WidgetStateProperty.all(EdgeInsets.zero),
+              backgroundColor: WidgetStateProperty.all(Colors.transparent),
+              shadowColor: WidgetStateProperty.all(Colors.transparent),
+              elevation: WidgetStateProperty.all(0),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (widget.icon != null) ...[
+                  widget.icon!,
+                  const SizedBox(width: 4),
+                ],
+                widget.child ?? Text(widget.buttonText, style: textStyle)
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return SizedBox(
+      width: widget.width,
+      height: widget.height,
+      child: Container(
+        decoration: BoxDecoration(
+          border: border,
+          borderRadius: BorderRadius.circular(50),
+          boxShadow: isHovered ? [boxShadow] : null,
+        ),
+        child: ElevatedButton(
+          onPressed: widget.disabled ? null : widget.onPressed,
+          onHover: (value) => setState(() => isHovered = value),
+          style: style,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (widget.icon != null) ...[
+                widget.icon!,
+                const SizedBox(width: 4),
+              ],
+              widget.child ?? Text(widget.buttonText, style: textStyle)
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
 
 class HorizonGradientButton extends StatefulWidget {
   final VoidCallback? onPressed;
@@ -377,15 +604,14 @@ class _HorizonRedesignDropdownState<T>
                                   child: Container(
                                     padding: const EdgeInsets.symmetric(
                                       horizontal: 12,
-                                      vertical: 16,
+                                      vertical: 21,
                                     ),
                                     child: Row(
                                       mainAxisAlignment:
-                                          MainAxisAlignment.center,
+                                          MainAxisAlignment.spaceBetween,
                                       children: [
                                         DefaultTextStyle(
-                                          style: theme
-                                              .dropdownMenuTheme.textStyle!,
+                                          style: theme.dropdownMenuTheme.textStyle!,
                                           child: item.child,
                                         ),
                                       ],
@@ -435,6 +661,20 @@ class _HorizonRedesignDropdownState<T>
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: widget.items.map((item) {
+                  TextStyle textStyle = theme.dropdownMenuTheme.textStyle!;
+                  if (item.child is Text) {
+                    final Text text = item.child as Text;
+                    textStyle = textStyle.copyWith(
+                      color: text.style?.color,
+                      fontSize: text.style?.fontSize,
+                      fontWeight: text.style?.fontWeight,
+                      fontStyle: text.style?.fontStyle,
+                      letterSpacing: text.style?.letterSpacing,
+                      wordSpacing: text.style?.wordSpacing,
+                      height: text.style?.height,
+                      decoration: text.style?.decoration,
+                    );
+                  }
                   return Material(
                     color: Colors.transparent,
                     child: InkWell(
@@ -451,7 +691,7 @@ class _HorizonRedesignDropdownState<T>
                           children: [
                             Expanded(
                               child: DefaultTextStyle(
-                                style: theme.dropdownMenuTheme.textStyle!,
+                                style: textStyle,
                                 child: item.child,
                               ),
                             ),
@@ -711,10 +951,7 @@ class _BlurredBackgroundDropdownState<T>
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
-                              DefaultTextStyle(
-                                style: theme.dropdownMenuTheme.textStyle!,
-                                child: item.child,
-                              ),
+                              item.child,
                             ],
                           ),
                         ),

--- a/lib/presentation/screens/onboarding/view/onboarding_page.dart
+++ b/lib/presentation/screens/onboarding/view/onboarding_page.dart
@@ -196,36 +196,29 @@ class OnboardingView extends StatelessWidget {
                                   const SizedBox(height: 20),
                                 ],
                                 SizedBox(
-                                  height: 64,
-                                  width: screenWidth > 500
-                                      ? screenWidth * 0.5
-                                      : null,
-                                  child: HorizonGradientButton(
-                                    onPressed: isDisabled
-                                        ? null
-                                        : () {
-                                            final session = context
-                                                .read<SessionStateCubit>();
-                                            session.onOnboardingCreate();
-                                          },
+                                  width: double.infinity,
+                                  child: HorizonButton(
+                                    disabled: isDisabled,
+                                    variant: ButtonVariant.gradient,
+                                    onPressed: () {
+                                      final session =
+                                          context.read<SessionStateCubit>();
+                                      session.onOnboardingCreate();
+                                    },
                                     buttonText: 'Create a new wallet',
                                   ),
                                 ),
                                 const SizedBox(height: 16),
                                 SizedBox(
-                                  height: 64,
-                                  width: screenWidth > 500
-                                      ? screenWidth * 0.5
-                                      : null,
-                                  child: HorizonOutlinedButton(
-                                    isTransparent: true,
-                                    onPressed: isDisabled
-                                        ? null
-                                        : () {
-                                            final session = context
-                                                .read<SessionStateCubit>();
-                                            session.onOnboardingImport();
-                                          },
+                                  width: double.infinity,
+                                  child: HorizonButton(
+                                    variant: ButtonVariant.black,
+                                    disabled: isDisabled,
+                                    onPressed: () {
+                                      final session = context
+                                          .read<SessionStateCubit>();
+                                      session.onOnboardingImport();
+                                    },
                                     buttonText: 'Load seed phrase',
                                   ),
                                 ),

--- a/lib/presentation/screens/onboarding/view/onboarding_shell.dart
+++ b/lib/presentation/screens/onboarding/view/onboarding_shell.dart
@@ -112,12 +112,9 @@ class _OnboardingShellState extends State<OnboardingShell> {
                   children: [
                     Expanded(
                       child: SizedBox(
-                        height: 64,
-                        child: HorizonOutlinedButton(
-                          isTransparent: false,
-                          onPressed: widget.nextButtonEnabled
-                              ? _handleStepContinue
-                              : null,
+                        child: HorizonButton(
+                          disabled: !widget.nextButtonEnabled,
+                          onPressed: _handleStepContinue,
                           buttonText: _currentStep == widget.steps.length - 1
                               ? widget.nextButtonText
                               : 'Continue',

--- a/lib/presentation/screens/onboarding_create/view/onboarding_create_page.dart
+++ b/lib/presentation/screens/onboarding_create/view/onboarding_create_page.dart
@@ -13,6 +13,7 @@ import 'package:horizon/presentation/common/redesign_colors.dart';
 import 'package:horizon/presentation/common/theme_extension.dart';
 import 'package:horizon/presentation/common/usecase/import_wallet_usecase.dart';
 import 'package:horizon/presentation/common/widgets/numbered_grid.dart';
+import 'package:horizon/presentation/screens/horizon/redesign_ui.dart';
 import 'package:horizon/presentation/screens/onboarding/view/onboarding_shell.dart';
 import 'package:horizon/presentation/screens/onboarding/view/password_prompt.dart';
 import 'package:horizon/presentation/screens/onboarding/view/seed_input.dart';
@@ -316,11 +317,9 @@ class ShowMnemonicStep extends StatelessWidget {
                   const SizedBox(height: 16),
                   if (config.network == Network.testnet4 ||
                       config.network == Network.testnet)
-                    ElevatedButton.icon(
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: green2,
-                        foregroundColor: Colors.black,
-                      ),
+                    HorizonButton(
+                      width: 150,
+                      buttonText: '',
                       onPressed: () {
                         Clipboard.setData(ClipboardData(text: mnemonic));
                         ScaffoldMessenger.of(context).showSnackBar(
@@ -329,10 +328,18 @@ class ShowMnemonicStep extends StatelessWidget {
                             duration: Duration(seconds: 2),
                           ),
                         );
-                      },
-                      icon: const Icon(Icons.copy),
-                      label: const Text('COPY'),
+                      },  
+                      child: const Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        spacing: 2,
+                        children: [
+                          Icon(Icons.copy),
+                          Text('Copy'),
+                        ],
+                      ),
                     ),
+                      
                 ],
               ),
               const SizedBox(height: 16),

--- a/lib/presentation/screens/onboarding_import/view/onboarding_import_page.dart
+++ b/lib/presentation/screens/onboarding_import/view/onboarding_import_page.dart
@@ -215,12 +215,14 @@ class _ChooseFormatStepState extends State<ChooseFormatStep> {
                     DropdownMenuItem(
                       value: WalletType.horizon.name,
                       child: Text(WalletType.horizon.description,
-                          style: Theme.of(context).textTheme.bodySmall),
+                          style: Theme.of(context).textTheme.bodySmall,
+                          textAlign: TextAlign.left),
                     ),
                     DropdownMenuItem(
                       value: WalletType.bip32.name,
                       child: Text(WalletType.bip32.description,
-                          style: Theme.of(context).textTheme.bodySmall),
+                          style: Theme.of(context).textTheme.bodySmall,
+                          textAlign: TextAlign.left),
                     ),
                   ],
                 ),

--- a/lib/presentation/screens/settings/security_view.dart
+++ b/lib/presentation/screens/settings/security_view.dart
@@ -170,7 +170,7 @@ class _SecurityViewState extends State<SecurityView> {
                 items: _timeoutOptions.entries
                     .map((entry) => DropdownMenuItem<int>(
                           value: entry.key,
-                          child: Text(entry.value),
+                          child: Text(entry.value, textAlign: TextAlign.center),
                         ))
                     .toList(),
                 onChanged: _onTimeoutChanged,


### PR DESCRIPTION
- variants (black, green, gradient, disabled) as per figma
- icon support
- can render custom widget inside button in place of text
- fixed height from 64 to 54

![image](https://github.com/user-attachments/assets/ea95e54c-0306-4fb8-9121-a75e5f800a6c)

![image](https://github.com/user-attachments/assets/d4e3ed5f-45b6-420f-a556-3ba02a4bc109)
