### PR TITLE
Fix getAddresses() on pages with specials chars in metas

### DIFF
--- a/lib/data/sources/repositories/action_repository_impl.dart
+++ b/lib/data/sources/repositories/action_repository_impl.dart
@@ -15,6 +15,38 @@ const Set<String> originWhitelist = {
   "https://horizon-market-signet.vercel.app"
 };
 
+// Free-text fields that may contain arbitrary user-supplied content (dApp page
+// title, favicon URL, message-to-sign, etc.) are encoded by `web/background.js`
+// using `encodeFreeText`, which produces a "b64:" prefix followed by URL-safe
+// base64 of the UTF-8 bytes. This survives any URL re-encoding done by Chrome
+// or GoRouter on the popup URL (en-dashes, accents, "&", "+", "%", ...).
+//
+// For backward compatibility with older payloads (and existing test fixtures
+// that still pass percent-encoded values), we also accept legacy strings: if
+// the value isn't tagged with "b64:" we fall back to `Uri.decodeComponent`
+// (idempotent for plain ASCII), and on any percent-decoding failure we just
+// return the raw string — which is what `state.uri.queryParameters` has
+// already produced once.
+String _decodeFreeText(String raw) {
+  if (raw.startsWith('b64:')) {
+    var s = raw.substring(4);
+    s = s.replaceAll('-', '+').replaceAll('_', '/');
+    while (s.length % 4 != 0) {
+      s += '=';
+    }
+    try {
+      return utf8.decode(base64.decode(s));
+    } catch (_) {
+      return raw;
+    }
+  }
+  try {
+    return Uri.decodeComponent(raw);
+  } catch (_) {
+    return raw;
+  }
+}
+
 RPCSignPsbtAction _buildSignPsbtAction({
   required String tabId,
   required String requestId,
@@ -27,9 +59,9 @@ RPCSignPsbtAction _buildSignPsbtAction({
   required String txInfoB64,
 }) {
   final intTabId = int.parse(tabId);
-  final decOrigin = Uri.decodeComponent(origin);
-  final decTitle = Uri.decodeComponent(title);
-  final decFavicon = Uri.decodeComponent(favicon);
+  final decOrigin = _decodeFreeText(origin);
+  final decTitle = _decodeFreeText(title);
+  final decFavicon = _decodeFreeText(favicon);
 
   final signInputs =
       _parseSignInputs(signInputsB64); // throws on bad format (kept)
@@ -474,9 +506,9 @@ class ActionRepositoryImpl implements ActionRepository {
         return RPCGetAddressesAction(
           int.parse(parts[1]),
           parts[2],
-          Uri.decodeComponent(parts[3]),
-          Uri.decodeComponent(parts[4]),
-          Uri.decodeComponent(parts[5]),
+          _decodeFreeText(parts[3]),
+          _decodeFreeText(parts[4]),
+          _decodeFreeText(parts[5]),
         );
 
       case 'signPsbt':
@@ -518,11 +550,10 @@ class ActionRepositoryImpl implements ActionRepository {
         return RPCSignMessageAction(
           int.parse(parts[1]),
           parts[2],
-          Uri.decodeComponent(parts[3]),
-          Uri.decodeComponent(parts[4]),
-          Uri.decodeComponent(parts[5]),
-          // DECODE the message so "Hello%20World" => "Hello World"
-          Uri.decodeComponent(parts[6]),
+          _decodeFreeText(parts[3]),
+          _decodeFreeText(parts[4]),
+          _decodeFreeText(parts[5]),
+          _decodeFreeText(parts[6]),
           parts[7],
         );
 
@@ -531,19 +562,19 @@ class ActionRepositoryImpl implements ActionRepository {
           throw Exception(
               'signMessageBLS expects 7-10 fields, got ${parts.length}');
         }
-        final msgField = Uri.decodeComponent(parts[6]);
+        final msgField = _decodeFreeText(parts[6]);
         final dstField =
-            parts.length >= 8 ? Uri.decodeComponent(parts[7]) : null;
+            parts.length >= 8 ? _decodeFreeText(parts[7]) : null;
         final msgHexField =
-            parts.length >= 9 ? Uri.decodeComponent(parts[8]) : null;
+            parts.length >= 9 ? _decodeFreeText(parts[8]) : null;
         final addrField =
-            parts.length >= 10 ? Uri.decodeComponent(parts[9]) : null;
+            parts.length >= 10 ? _decodeFreeText(parts[9]) : null;
         return RPCSignMessageBLSAction(
           int.parse(parts[1]),
           parts[2],
-          Uri.decodeComponent(parts[3]),
-          Uri.decodeComponent(parts[4]),
-          Uri.decodeComponent(parts[5]),
+          _decodeFreeText(parts[3]),
+          _decodeFreeText(parts[4]),
+          _decodeFreeText(parts[5]),
           msgField,
           dstField != null && dstField.isNotEmpty ? dstField : null,
           msgHexField != null && msgHexField.isNotEmpty ? msgHexField : null,
@@ -558,10 +589,10 @@ class ActionRepositoryImpl implements ActionRepository {
         return RPCGetBLSPoPAction(
           int.parse(parts[1]),
           parts[2],
-          Uri.decodeComponent(parts[3]),
-          Uri.decodeComponent(parts[4]),
-          Uri.decodeComponent(parts[5]),
-          Uri.decodeComponent(parts[6]),
+          _decodeFreeText(parts[3]),
+          _decodeFreeText(parts[4]),
+          _decodeFreeText(parts[5]),
+          _decodeFreeText(parts[6]),
         );
 
       case 'exportEncryptedBlsPrivateKey':
@@ -570,13 +601,13 @@ class ActionRepositoryImpl implements ActionRepository {
               'exportEncryptedBlsPrivateKey expects 6-7 fields, got ${parts.length}');
         }
         final exportAddrField =
-            parts.length >= 7 ? Uri.decodeComponent(parts[6]) : null;
+            parts.length >= 7 ? _decodeFreeText(parts[6]) : null;
         return RPCExportEncryptedBlsPrivateKeyAction(
           int.parse(parts[1]),
           parts[2],
-          Uri.decodeComponent(parts[3]),
-          Uri.decodeComponent(parts[4]),
-          Uri.decodeComponent(parts[5]),
+          _decodeFreeText(parts[3]),
+          _decodeFreeText(parts[4]),
+          _decodeFreeText(parts[5]),
           exportAddrField != null && exportAddrField.isNotEmpty
               ? exportAddrField
               : null,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
-import 'package:horizon/common/fn.dart';
 import 'package:horizon/core/logging/logger.dart';
 import 'package:horizon/domain/repositories/action_repository.dart';
 import 'package:horizon/domain/repositories/config_repository.dart';
@@ -1017,9 +1016,27 @@ class AppRouter {
         final ActionRepository actionRepository =
             GetIt.instance<ActionRepository>();
         if (actionParam != null) {
-          actionRepository
-              .fromString(actionParam)
-              .fold(noop1, (action) => actionRepository.enqueue(action));
+          actionRepository.fromString(actionParam).fold(
+            (failure) {
+              // Don't swallow the failure: a parser error here means the dApp
+              // popup just opened to the wrong screen (typically PortfolioView)
+              // because we couldn't decode the requested RPC. Surfacing this
+              // to logs + Sentry makes the failure debuggable instead of
+              // looking like the user simply rejected the request.
+              GetIt.I<Logger>().error(
+                'Failed to parse action param "$actionParam": $failure',
+              );
+              GetIt.I<ErrorService>().captureException(
+                Exception('ActionRepository.fromString failed: $failure'),
+                message: 'Failed to parse action param',
+                context: {
+                  'actionParam': actionParam,
+                  'failure': failure,
+                },
+              );
+            },
+            (action) => actionRepository.enqueue(action),
+          );
         }
 
         final path = session.state.maybeWhen(

--- a/test/action_repository_impl_test.dart
+++ b/test/action_repository_impl_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:horizon/domain/entities/asset_quantity.dart';
@@ -881,6 +882,254 @@ void main() {
 
       // Assert
       expect(result.isLeft(), true);
+    });
+  });
+
+  // Regression tests for the bug where dApp page titles containing Unicode
+  // multi-byte chars (en-dash, accents) or URL-reserved chars (&) would crash
+  // the parser. The popup would silently fall back to PortfolioView instead
+  // of opening the requested RPC screen.
+  //
+  // Background: in production, the action string is read via
+  // `state.uri.queryParameters['action']`, which already URL-decodes values
+  // once. So values reaching `fromString` are either:
+  //   - newly tagged with "b64:" (URL-safe base64 of UTF-8) — the new format
+  //   - plain decoded text (e.g., "Bitcoin NFTs & Counterparty" with literal
+  //     "&", or "Marketplace – Ordinals" with literal en-dash) — legacy/path
+  //     after Uri.queryParameters has decoded
+  //
+  // The parser must handle both without throwing.
+  group("free-text decoding (Unicode/&/+ regression)", () {
+    String b64(String s) {
+      final std = base64.encode(utf8.encode(s));
+      final urlSafe = std
+          .replaceAll('+', '-')
+          .replaceAll('/', '_')
+          .replaceAll(RegExp(r'=+$'), '');
+      return 'b64:$urlSafe';
+    }
+
+    group('getAddresses', () {
+      test('decodes b64-tagged title with en-dash (U+2013)', () {
+        const title = 'Horizon Market | Bitcoin NFT Marketplace – Ordinals';
+        const favicon = 'https://localhost:3002/favicon.ico';
+        final encoded =
+            'getAddresses,1,abc,https%3A%2F%2Flocalhost%3A3002,${b64(title)},${b64(favicon)}';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue);
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) {
+            final action = r as RPCGetAddressesAction;
+            expect(action.title, title);
+            expect(action.favicon, favicon);
+          },
+        );
+      });
+
+      test('decodes b64-tagged title with literal & and accents', () {
+        const title = 'Café & Tëst — em-dash';
+        final encoded =
+            'getAddresses,1,abc,https%3A%2F%2Fexample.com,${b64(title)},${b64("")}';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue);
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) => expect((r as RPCGetAddressesAction).title, title),
+        );
+      });
+
+      test(
+          'legacy path: already-decoded Unicode title falls back to raw '
+          '(does not throw)', () {
+        // Simulates what state.uri.queryParameters['action']' produces when
+        // the JS side encoded "Marketplace – Ordinals" with encodeURIComponent
+        // (so on the wire it's "Marketplace%20%E2%80%93%20Ordinals") and
+        // GoRouter's Uri.queryParameters decoded it once before split.
+        const alreadyDecodedTitle = 'Marketplace – Ordinals';
+        final encoded =
+            'getAddresses,1,abc,https://example.com,$alreadyDecodedTitle,';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue,
+            reason:
+                'Parser must not throw on already-decoded multi-byte chars');
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) => expect((r as RPCGetAddressesAction).title, alreadyDecodedTitle),
+        );
+      });
+
+      test(
+          'legacy path: already-decoded title with literal % falls back '
+          'to raw (does not throw)', () {
+        // Uri.decodeComponent("100% off") would throw "Invalid URL encoding".
+        const alreadyDecodedTitle = '100% off launch';
+        final encoded =
+            'getAddresses,1,abc,https://example.com,$alreadyDecodedTitle,';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue);
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) => expect((r as RPCGetAddressesAction).title, alreadyDecodedTitle),
+        );
+      });
+
+      test('b64 with empty payload yields empty string', () {
+        final encoded =
+            'getAddresses,1,abc,https://example.com,${b64("")},${b64("")}';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue);
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) {
+            final action = r as RPCGetAddressesAction;
+            expect(action.title, '');
+            expect(action.favicon, '');
+          },
+        );
+      });
+    });
+
+    group('signMessage', () {
+      test('decodes b64-tagged message containing reserved chars', () {
+        const message = 'Sign me & verify – ok? 50%';
+        const title = 'dApp – Tëst';
+        final encoded =
+            'signMessage,1,abc,https%3A%2F%2Fexample.com,${b64(title)},${b64("")},${b64(message)},bc1qaddress';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue);
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) {
+            final action = r as RPCSignMessageAction;
+            expect(action.title, title);
+            expect(action.message, message);
+            expect(action.address, 'bc1qaddress');
+          },
+        );
+      });
+    });
+
+    group('signMessageBLS', () {
+      test('decodes b64-tagged title and message with Unicode', () {
+        const title = 'BLS dApp – signing';
+        const message = 'Hello – World & friends';
+        final encoded =
+            'signMessageBLS,1,abc,https%3A%2F%2Fexample.com,${b64(title)},${b64("")},${b64(message)}';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue);
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) {
+            final action = r as RPCSignMessageBLSAction;
+            expect(action.title, title);
+            expect(action.message, message);
+          },
+        );
+      });
+    });
+
+    group('signPsbt', () {
+      test('decodes b64-tagged title with Unicode in real-style payload', () {
+        const title = 'Horizon Market | Trade Bitcoin NFTs – Ordinals & Pepes';
+        // Re-uses an existing valid signInputs/sighash/txInfo payload.
+        const signInputs =
+            'eyJiYzFxNHNoM3Nma3BwbGc1djgwZ2E5MDd6N2dubWhrdHlxcXZlN3k1bjIiOlswXX0=';
+        const sighashes = 'WzEzMSwxLDJd';
+        const txInfo = 'bnVsbA==';
+        const psbtHex = 'deadbeef';
+
+        final encoded =
+            'signPsbt,1,abc,https://horizon.market,${b64(title)},${b64("")},$psbtHex,$signInputs,$sighashes,$txInfo';
+
+        final result = actionRepository.fromString(encoded);
+
+        expect(result.isRight(), isTrue);
+        result.match(
+          (l) => fail('Expected Right but got Left: $l'),
+          (r) {
+            final action = r as RPCSignPsbtAction;
+            expect(action.title, title);
+            expect(action.origin, 'https://horizon.market');
+          },
+        );
+      });
+    });
+
+    // Full end-to-end simulation of the production data flow:
+    //   1. web/background.js builds the popup URL with `encodeFreeText` for
+    //      title/favicon and `encodeURIComponent` for origin.
+    //   2. Chrome opens the popup at that URL; GoRouter parses the fragment
+    //      via `Uri.parse(...).queryParameters['action']`, which decodes any
+    //      percent-escaped chars once.
+    //   3. The resulting string is passed to `actionRepository.fromString`.
+    //
+    // This test exercises (1)→(2)→(3) and asserts that the bug-report URL
+    // pattern (en-dash in title) now produces a real action instead of a
+    // silent failure.
+    test('end-to-end: bug-report URL with en-dash title resolves correctly',
+        () {
+      const tabId = 1262875154;
+      const requestId = '8b0cd14b-7b93-4f16-915f-859cf41a2251';
+      const origin = 'http://localhost:3002';
+      const title =
+          'Horizon Market | Bitcoin NFT Marketplace – Ordinals and Rare Pepes';
+      const favicon = 'http://localhost:3002/favicon.ico?favicon.66efc405.ico';
+
+      // Step 1: simulate background.js building the URL fragment.
+      String encodeFreeText(String s) {
+        final std = base64.encode(utf8.encode(s));
+        final urlSafe = std
+            .replaceAll('+', '-')
+            .replaceAll('/', '_')
+            .replaceAll(RegExp(r'=+$'), '');
+        return 'b64:$urlSafe';
+      }
+
+      final actionParam = [
+        'getAddresses',
+        '$tabId',
+        requestId,
+        Uri.encodeComponent(origin),
+        encodeFreeText(title),
+        encodeFreeText(favicon),
+      ].join(',');
+
+      final urlFragment = '?action=$actionParam';
+
+      // Step 2: simulate GoRouter's `state.uri.queryParameters['action']`.
+      final actionFromUri = Uri.parse(urlFragment).queryParameters['action']!;
+
+      // Step 3: parser must succeed and return the original strings round-tripped.
+      final result = actionRepository.fromString(actionFromUri);
+
+      expect(result.isRight(), isTrue,
+          reason: 'Parser must not fail on Unicode-bearing dApp titles');
+      result.match(
+        (l) => fail('Expected Right but got Left: $l'),
+        (r) {
+          final action = r as RPCGetAddressesAction;
+          expect(action.tabId, tabId);
+          expect(action.requestId, requestId);
+          expect(action.origin, origin);
+          expect(action.title, title);
+          expect(action.favicon, favicon);
+        },
+      );
     });
   });
 }

--- a/web/background.js
+++ b/web/background.js
@@ -8,6 +8,21 @@ function safeBtoaJson(value) {
   return btoa(unescape(encodeURIComponent(json)));
 }
 
+// URL-safe base64 of an arbitrary UTF-8 string. Uses the "b64:" prefix so the
+// Dart parser can unambiguously distinguish encoded payloads from legacy
+// percent-encoded values. The output never contains characters that would be
+// re-interpreted by URL parsers ("+", "/", "&", "%") so it survives any
+// re-encoding done by Chrome/GoRouter on the popup URL.
+function encodeFreeText(s) {
+  const str = s == null ? "" : String(s);
+  const stdB64 = btoa(unescape(encodeURIComponent(str)));
+  const urlSafe = stdB64
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return "b64:" + urlSafe;
+}
+
 function encodeTransactionInfo(transactionInfo) {
   if (!transactionInfo) return undefined;
   try {
@@ -109,7 +124,7 @@ async function rpcGetAddresses(requestId, port) {
   const metadata = await getTabMetadata(tabId);
 
   const window = await popup({
-    url: `/index.html#?action=getAddresses,${tabId},${requestId},${encodeURIComponent(origin)},${encodeURIComponent(metadata.title)},${encodeURIComponent(metadata.favicon)}`,
+    url: `/index.html#?action=getAddresses,${tabId},${requestId},${encodeURIComponent(origin)},${encodeFreeText(metadata.title)},${encodeFreeText(metadata.favicon)}`,
   });
 
   listenForPopupClose({
@@ -147,8 +162,8 @@ async function rpcSignPsbt(
     tabId,
     requestId,
     encodeURIComponent(origin ?? ""),
-    encodeURIComponent(metadata.title ?? ""),
-    encodeURIComponent(metadata.favicon ?? ""),
+    encodeFreeText(metadata.title),
+    encodeFreeText(metadata.favicon),
     hex, // already hex-safe for URLs
     encodedSignInputs,
   ];
@@ -177,7 +192,7 @@ async function rpcSignMessage(requestId, port, message, address) {
   const tabId = getTabIdFromPort(port);
   const metadata = await getTabMetadata(tabId);
   const window = await popup({
-    url: `/index.html#?action=signMessage,${tabId},${requestId},${encodeURIComponent(origin)},${encodeURIComponent(metadata.title)},${encodeURIComponent(metadata.favicon)},${message},${address}`,
+    url: `/index.html#?action=signMessage,${tabId},${requestId},${encodeURIComponent(origin)},${encodeFreeText(metadata.title)},${encodeFreeText(metadata.favicon)},${encodeFreeText(message)},${address}`,
   });
   listenForPopupClose({
     id: window?.id,
@@ -199,9 +214,9 @@ async function rpcSignMessageBLS(requestId, port, message, dst, messageHex, addr
     tabId,
     requestId,
     encodeURIComponent(origin),
-    encodeURIComponent(metadata.title),
-    encodeURIComponent(metadata.favicon),
-    encodeURIComponent(message || ""),
+    encodeFreeText(metadata.title),
+    encodeFreeText(metadata.favicon),
+    encodeFreeText(message || ""),
     encodeURIComponent(dst || ""),
     encodeURIComponent(messageHex || ""),
     encodeURIComponent(address || ""),
@@ -230,8 +245,8 @@ async function rpcGetBLSPoP(requestId, port, address) {
     tabId,
     requestId,
     encodeURIComponent(origin),
-    encodeURIComponent(metadata.title),
-    encodeURIComponent(metadata.favicon),
+    encodeFreeText(metadata.title),
+    encodeFreeText(metadata.favicon),
     encodeURIComponent(address),
   ];
 
@@ -258,8 +273,8 @@ async function rpcExportEncryptedBlsPrivateKey(requestId, port, address) {
     tabId,
     requestId,
     encodeURIComponent(origin),
-    encodeURIComponent(metadata.title),
-    encodeURIComponent(metadata.favicon),
+    encodeFreeText(metadata.title),
+    encodeFreeText(metadata.favicon),
     encodeURIComponent(address || ""),
   ];
 


### PR DESCRIPTION
fix(rpc): base64-encode dApp title/favicon/message to survive URL re-encoding (en-dash, &, accents)