### PR TITLE
sats-connect support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ node_modules/
 android/app/.cxx/
 
 tool/node_modules/
+
+# Packaged extension build artifacts
+horizon_wallet_extension_chrome-*.zip

--- a/lib/data/sources/repositories/action_repository_impl.dart
+++ b/lib/data/sources/repositories/action_repository_impl.dart
@@ -613,6 +613,38 @@ class ActionRepositoryImpl implements ActionRepository {
               : null,
         );
 
+      case 'getBalance':
+        if (parts.length != 7) {
+          throw Exception('getBalance expects 7 fields, got ${parts.length}');
+        }
+        final balanceAddr = _decodeFreeText(parts[6]);
+        return RPCGetBalanceAction(
+          int.parse(parts[1]),
+          parts[2],
+          _decodeFreeText(parts[3]),
+          _decodeFreeText(parts[4]),
+          _decodeFreeText(parts[5]),
+          balanceAddr.isNotEmpty ? balanceAddr : null,
+        );
+
+      case 'sendTransfer':
+        if (parts.length != 8) {
+          throw Exception('sendTransfer expects 8 fields, got ${parts.length}');
+        }
+        final amount = int.tryParse(parts[7]);
+        if (amount == null || amount <= 0) {
+          throw Exception('sendTransfer: invalid amount "${parts[7]}"');
+        }
+        return RPCSendTransferAction(
+          int.parse(parts[1]),
+          parts[2],
+          _decodeFreeText(parts[3]),
+          _decodeFreeText(parts[4]),
+          _decodeFreeText(parts[5]),
+          _decodeFreeText(parts[6]),
+          amount,
+        );
+
       default:
         throw Exception('Unknown action: ${parts[0]}');
     }

--- a/lib/domain/entities/action.dart
+++ b/lib/domain/entities/action.dart
@@ -77,3 +77,23 @@ class RPCExportEncryptedBlsPrivateKeyAction extends RPCAction {
       super.tabId, super.requestId, super.origin, super.title, super.favicon,
       this.address);
 }
+
+// sats-connect `getBalance`. `address` is optional: when null the wallet uses
+// its payment (native-segwit) address.
+class RPCGetBalanceAction extends RPCAction {
+  @override
+  String get action => 'getBalance';
+  final String? address;
+  RPCGetBalanceAction(super.tabId, super.requestId, super.origin, super.title,
+      super.favicon, this.address);
+}
+
+// sats-connect `sendTransfer` (single recipient). `amount` is in satoshis.
+class RPCSendTransferAction extends RPCAction {
+  @override
+  String get action => 'sendTransfer';
+  final String destination;
+  final int amount;
+  RPCSendTransferAction(super.tabId, super.requestId, super.origin, super.title,
+      super.favicon, this.destination, this.amount);
+}

--- a/lib/domain/entities/extension_rpc.dart
+++ b/lib/domain/entities/extension_rpc.dart
@@ -103,3 +103,37 @@ class RPCExportEncryptedBlsPrivateKeySuccessCallbackArgs {
 
 typedef RPCExportEncryptedBlsPrivateKeySuccessCallback = void Function(
     RPCExportEncryptedBlsPrivateKeySuccessCallbackArgs);
+
+class RPCGetBalanceSuccessCallbackArgs {
+  final int tabId;
+  final String requestId;
+  final String confirmed;
+  final String unconfirmed;
+  final String total;
+
+  RPCGetBalanceSuccessCallbackArgs({
+    required this.tabId,
+    required this.requestId,
+    required this.confirmed,
+    required this.unconfirmed,
+    required this.total,
+  });
+}
+
+typedef RPCGetBalanceSuccessCallback = void Function(
+    RPCGetBalanceSuccessCallbackArgs);
+
+class RPCSendTransferSuccessCallbackArgs {
+  final int tabId;
+  final String requestId;
+  final String txid;
+
+  RPCSendTransferSuccessCallbackArgs({
+    required this.tabId,
+    required this.requestId,
+    required this.txid,
+  });
+}
+
+typedef RPCSendTransferSuccessCallback = void Function(
+    RPCSendTransferSuccessCallbackArgs);

--- a/lib/domain/entities/extension_rpc.dart
+++ b/lib/domain/entities/extension_rpc.dart
@@ -137,3 +137,24 @@ class RPCSendTransferSuccessCallbackArgs {
 
 typedef RPCSendTransferSuccessCallback = void Function(
     RPCSendTransferSuccessCallbackArgs);
+
+// Shared failure payload for the sats-connect getBalance / sendTransfer routes.
+// Lets a fatal (non-retryable) failure return the real reason to the dApp and
+// close the popup, instead of leaving the request hanging until the user
+// manually closes the window — which the background then reports, misleadingly,
+// as a user rejection.
+class RPCErrorCallbackArgs {
+  final int tabId;
+  final String requestId;
+  final String error;
+
+  RPCErrorCallbackArgs({
+    required this.tabId,
+    required this.requestId,
+    required this.error,
+  });
+}
+
+typedef RPCGetBalanceErrorCallback = void Function(RPCErrorCallbackArgs);
+
+typedef RPCSendTransferErrorCallback = void Function(RPCErrorCallbackArgs);

--- a/lib/domain/entities/extension_rpc.dart
+++ b/lib/domain/entities/extension_rpc.dart
@@ -155,6 +155,7 @@ class RPCErrorCallbackArgs {
   });
 }
 
-typedef RPCGetBalanceErrorCallback = void Function(RPCErrorCallbackArgs);
-
-typedef RPCSendTransferErrorCallback = void Function(RPCErrorCallbackArgs);
+// One error shape for every sats-connect RPC route: the JSON-RPC error is
+// identical regardless of which method failed, so a single callback type backs
+// them all (registered once, resolved by every route).
+typedef RPCErrorCallback = void Function(RPCErrorCallbackArgs);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,6 +66,11 @@ import 'package:horizon/presentation/forms/sign_psbt/view/sign_psbt_form.dart';
 import 'package:horizon/presentation/forms/sign_message/bloc/sign_message_bloc.dart';
 import 'package:horizon/presentation/forms/sign_message/view/sign_message_form.dart';
 
+import 'package:horizon/presentation/forms/get_balance/bloc/get_balance_bloc.dart';
+import 'package:horizon/presentation/forms/get_balance/view/get_balance_form.dart';
+import 'package:horizon/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart';
+import 'package:horizon/presentation/forms/send_transfer/view/send_transfer_form.dart';
+
 import 'package:horizon/presentation/forms/sign_message_bls/bloc/sign_message_bls_bloc.dart';
 import 'package:horizon/presentation/forms/sign_message_bls/view/sign_message_bls_form.dart';
 
@@ -572,6 +577,169 @@ class AppRouter {
                       )));
                 }),
             GoRoute(
+                path: "/rpc/get-balance",
+                builder: (context, state) {
+                  final session =
+                      context.watch<SessionStateCubit>().state.successOrThrow();
+
+                  final actionRepository = GetIt.I<ActionRepository>();
+
+                  final action = actionRepository.dequeue().getOrThrow()
+                      as RPCGetBalanceAction;
+
+                  final addresses = session.addressIndexSet.list;
+                  // sats-connect `getBalance` carries no address, so the
+                  // provider always omits it and we fall back to the payment
+                  // (native-segwit) address — `addresses.first`. The explicit
+                  // address branch only fires for a house caller that passes
+                  // one; an unknown address resolves to null below.
+                  final address =
+                      (action.address != null && action.address!.isNotEmpty)
+                          ? session.addressIndexSet.getByAddress(action.address!)
+                          : (addresses.isNotEmpty ? addresses.first : null);
+
+                  if (address == null) {
+                    return ActionHandlerShell(
+                        child: Padding(
+                      padding: const EdgeInsets.all(24.0),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          DAppInfoWidget(
+                            title: 'VIEW BALANCE',
+                            dappUrl: action.origin,
+                            dappTitle: action.title,
+                            dappFavicon: action.favicon,
+                          ),
+                          const Expanded(
+                            child: Center(
+                              child:
+                                  Text("No address available in current account"),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ));
+                  }
+
+                  return BlocProvider(
+                      create: (_) => GetBalanceBloc(
+                            address: address.address,
+                            httpConfig: session.httpConfig,
+                          ),
+                      child: ActionHandlerShell(
+                          child: Padding(
+                        padding: const EdgeInsets.all(24.0),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            DAppInfoWidget(
+                              title: 'VIEW BALANCE',
+                              dappUrl: action.origin,
+                              dappTitle: action.title,
+                              dappFavicon: action.favicon,
+                            ),
+                            GetBalanceForm(
+                              onSuccess: (confirmed, unconfirmed, total) {
+                                GetIt.I<RPCGetBalanceSuccessCallback>()(
+                                    RPCGetBalanceSuccessCallbackArgs(
+                                  tabId: action.tabId,
+                                  requestId: action.requestId,
+                                  confirmed: confirmed,
+                                  unconfirmed: unconfirmed,
+                                  total: total,
+                                ));
+                              },
+                            ),
+                          ],
+                        ),
+                      )));
+                }),
+            GoRoute(
+                path: "/rpc/send-transfer",
+                builder: (context, state) {
+                  final session =
+                      context.watch<SessionStateCubit>().state.successOrThrow();
+
+                  final actionRepository = GetIt.I<ActionRepository>();
+
+                  final action = actionRepository.dequeue().getOrThrow()
+                      as RPCSendTransferAction;
+
+                  final addresses = session.addressIndexSet.list;
+                  // Send from the wallet's payment address (native segwit is
+                  // first by AddressIndexSet priority).
+                  final source = addresses.isNotEmpty ? addresses.first : null;
+
+                  if (source == null) {
+                    return ActionHandlerShell(
+                        child: Padding(
+                      padding: const EdgeInsets.all(24.0),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          DAppInfoWidget(
+                            title: 'SEND BITCOIN',
+                            dappUrl: action.origin,
+                            dappTitle: action.title,
+                            dappFavicon: action.favicon,
+                          ),
+                          const Expanded(
+                            child: Center(
+                              child:
+                                  Text("No address available in current account"),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ));
+                  }
+
+                  return BlocProvider(
+                      create: (_) => SendTransferBloc(
+                            source: source,
+                            destination: action.destination,
+                            amount: action.amount,
+                            httpConfig: session.httpConfig,
+                            passwordRequired: GetIt.I<SettingsRepository>()
+                                .requirePasswordForCryptoOperations,
+                          ),
+                      child: ActionHandlerShell(
+                          child: Padding(
+                        padding: const EdgeInsets.all(24.0),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            DAppInfoWidget(
+                              title: 'SEND BITCOIN',
+                              dappUrl: action.origin,
+                              dappTitle: action.title,
+                              dappFavicon: action.favicon,
+                            ),
+                            SendTransferForm(
+                              passwordRequired: GetIt.I<SettingsRepository>()
+                                  .requirePasswordForCryptoOperations,
+                              destination: action.destination,
+                              amount: action.amount,
+                              source: source.address,
+                              onSuccess: (txid) {
+                                GetIt.I<RPCSendTransferSuccessCallback>()(
+                                    RPCSendTransferSuccessCallbackArgs(
+                                  tabId: action.tabId,
+                                  requestId: action.requestId,
+                                  txid: txid,
+                                ));
+                              },
+                            ),
+                          ],
+                        ),
+                      )));
+                }),
+            GoRoute(
                 path: "/rpc/sign-message-bls",
                 builder: (context, state) {
                   final session =
@@ -1062,6 +1230,8 @@ class AppRouter {
                         RPCSignPsbtAction() => "/rpc/sign-psbt",
                         RPCExportEncryptedBlsPrivateKeyAction() =>
                           "/rpc/export-encrypted-bls-private-key",
+                        RPCGetBalanceAction() => "/rpc/get-balance",
+                        RPCSendTransferAction() => "/rpc/send-transfer",
                         _ => null
                       });
 
@@ -1084,6 +1254,8 @@ class AppRouter {
                         RPCSignPsbtAction() => "/rpc/sign-psbt",
                         RPCExportEncryptedBlsPrivateKeyAction() =>
                           "/rpc/export-encrypted-bls-private-key",
+                        RPCGetBalanceAction() => "/rpc/get-balance",
+                        RPCSendTransferAction() => "/rpc/send-transfer",
                         _ => null
                       });
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -273,6 +273,39 @@ int _resolveAccountIndex(SessionStateSuccess session, String? address) {
       : 0;
 }
 
+// Empty-state shell shown by the sats-connect getBalance / sendTransfer routes
+// when the active account has no usable address. Kept as a single helper so the
+// two routes can't drift apart.
+Widget _noAddressActionShell({
+  required String title,
+  required String? dappUrl,
+  required String? dappTitle,
+  required String? dappFavicon,
+}) {
+  return ActionHandlerShell(
+    child: Padding(
+      padding: const EdgeInsets.all(24.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DAppInfoWidget(
+            title: title,
+            dappUrl: dappUrl,
+            dappTitle: dappTitle,
+            dappFavicon: dappFavicon,
+          ),
+          const Expanded(
+            child: Center(
+              child: Text("No address available in current account"),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
 class AppRouter {
   static GoRouter router = GoRouter(
       navigatorKey: _rootNavigatorKey,
@@ -599,28 +632,12 @@ class AppRouter {
                           : (addresses.isNotEmpty ? addresses.first : null);
 
                   if (address == null) {
-                    return ActionHandlerShell(
-                        child: Padding(
-                      padding: const EdgeInsets.all(24.0),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          DAppInfoWidget(
-                            title: 'VIEW BALANCE',
-                            dappUrl: action.origin,
-                            dappTitle: action.title,
-                            dappFavicon: action.favicon,
-                          ),
-                          const Expanded(
-                            child: Center(
-                              child:
-                                  Text("No address available in current account"),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ));
+                    return _noAddressActionShell(
+                      title: 'VIEW BALANCE',
+                      dappUrl: action.origin,
+                      dappTitle: action.title,
+                      dappFavicon: action.favicon,
+                    );
                   }
 
                   return BlocProvider(
@@ -674,28 +691,12 @@ class AppRouter {
                   final source = addresses.isNotEmpty ? addresses.first : null;
 
                   if (source == null) {
-                    return ActionHandlerShell(
-                        child: Padding(
-                      padding: const EdgeInsets.all(24.0),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          DAppInfoWidget(
-                            title: 'SEND BITCOIN',
-                            dappUrl: action.origin,
-                            dappTitle: action.title,
-                            dappFavicon: action.favicon,
-                          ),
-                          const Expanded(
-                            child: Center(
-                              child:
-                                  Text("No address available in current account"),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ));
+                    return _noAddressActionShell(
+                      title: 'SEND BITCOIN',
+                      dappUrl: action.origin,
+                      dappTitle: action.title,
+                      dappFavicon: action.favicon,
+                    );
                   }
 
                   return BlocProvider(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -274,36 +274,66 @@ int _resolveAccountIndex(SessionStateSuccess session, String? address) {
 }
 
 // Empty-state shell shown by the sats-connect getBalance / sendTransfer routes
-// when the active account has no usable address. Kept as a single helper so the
+// when the active account has no usable address. Kept as a single widget so the
 // two routes can't drift apart.
-Widget _noAddressActionShell({
-  required String title,
-  required String? dappUrl,
-  required String? dappTitle,
-  required String? dappFavicon,
-}) {
-  return ActionHandlerShell(
-    child: Padding(
-      padding: const EdgeInsets.all(24.0),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          DAppInfoWidget(
-            title: title,
-            dappUrl: dappUrl,
-            dappTitle: dappTitle,
-            dappFavicon: dappFavicon,
-          ),
-          const Expanded(
-            child: Center(
-              child: Text("No address available in current account"),
+//
+// Besides rendering the message, it surfaces a real error to the dApp (and
+// closes the popup) via [onError] once mounted — otherwise the request would
+// hang until the user manually closes the window, which the background then
+// misreports as a user rejection. Mirrors the form-driven error path.
+class _NoAddressActionShell extends StatefulWidget {
+  final String title;
+  final String? dappUrl;
+  final String? dappTitle;
+  final String? dappFavicon;
+  final void Function(String error) onError;
+
+  const _NoAddressActionShell({
+    required this.title,
+    required this.dappUrl,
+    required this.dappTitle,
+    required this.dappFavicon,
+    required this.onError,
+  });
+
+  @override
+  State<_NoAddressActionShell> createState() => _NoAddressActionShellState();
+}
+
+class _NoAddressActionShellState extends State<_NoAddressActionShell> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.onError('No address available in current account');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionHandlerShell(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            DAppInfoWidget(
+              title: widget.title,
+              dappUrl: widget.dappUrl,
+              dappTitle: widget.dappTitle,
+              dappFavicon: widget.dappFavicon,
             ),
-          ),
-        ],
+            const Expanded(
+              child: Center(
+                child: Text("No address available in current account"),
+              ),
+            ),
+          ],
+        ),
       ),
-    ),
-  );
+    );
+  }
 }
 
 class AppRouter {
@@ -632,11 +662,19 @@ class AppRouter {
                           : (addresses.isNotEmpty ? addresses.first : null);
 
                   if (address == null) {
-                    return _noAddressActionShell(
+                    return _NoAddressActionShell(
                       title: 'VIEW BALANCE',
                       dappUrl: action.origin,
                       dappTitle: action.title,
                       dappFavicon: action.favicon,
+                      onError: (error) {
+                        GetIt.I<RPCGetBalanceErrorCallback>()(
+                            RPCErrorCallbackArgs(
+                          tabId: action.tabId,
+                          requestId: action.requestId,
+                          error: error,
+                        ));
+                      },
                     );
                   }
 
@@ -699,11 +737,19 @@ class AppRouter {
                   final source = addresses.isNotEmpty ? addresses.first : null;
 
                   if (source == null) {
-                    return _noAddressActionShell(
+                    return _NoAddressActionShell(
                       title: 'SEND BITCOIN',
                       dappUrl: action.origin,
                       dappTitle: action.title,
                       dappFavicon: action.favicon,
+                      onError: (error) {
+                        GetIt.I<RPCSendTransferErrorCallback>()(
+                            RPCErrorCallbackArgs(
+                          tabId: action.tabId,
+                          requestId: action.requestId,
+                          error: error,
+                        ));
+                      },
                     );
                   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -669,6 +669,14 @@ class AppRouter {
                                   total: total,
                                 ));
                               },
+                              onError: (error) {
+                                GetIt.I<RPCGetBalanceErrorCallback>()(
+                                    RPCErrorCallbackArgs(
+                                  tabId: action.tabId,
+                                  requestId: action.requestId,
+                                  error: error,
+                                ));
+                              },
                             ),
                           ],
                         ),
@@ -733,6 +741,14 @@ class AppRouter {
                                   tabId: action.tabId,
                                   requestId: action.requestId,
                                   txid: txid,
+                                ));
+                              },
+                              onError: (error) {
+                                GetIt.I<RPCSendTransferErrorCallback>()(
+                                    RPCErrorCallbackArgs(
+                                  tabId: action.tabId,
+                                  requestId: action.requestId,
+                                  error: error,
                                 ));
                               },
                             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -273,6 +273,46 @@ int _resolveAccountIndex(SessionStateSuccess session, String? address) {
       : 0;
 }
 
+// Standard chrome for a sats-connect RPC popup: the dApp banner followed by the
+// route's body. Shared by getBalance / sendTransfer (and the no-address shell)
+// so the scaffolding lives in exactly one place.
+Widget _rpcActionScaffold({
+  required String title,
+  required String? dappUrl,
+  required String? dappTitle,
+  required String? dappFavicon,
+  required Widget child,
+}) {
+  return ActionHandlerShell(
+    child: Padding(
+      padding: const EdgeInsets.all(24.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DAppInfoWidget(
+            title: title,
+            dappUrl: dappUrl,
+            dappTitle: dappTitle,
+            dappFavicon: dappFavicon,
+          ),
+          child,
+        ],
+      ),
+    ),
+  );
+}
+
+// Hand a fatal error for [action] back to the dApp (and close the popup) through
+// the shared error callback. Identical for every sats-connect RPC route.
+void _emitRpcError(RPCAction action, String error) {
+  GetIt.I<RPCErrorCallback>()(RPCErrorCallbackArgs(
+    tabId: action.tabId,
+    requestId: action.requestId,
+    error: error,
+  ));
+}
+
 // Empty-state shell shown by the sats-connect getBalance / sendTransfer routes
 // when the active account has no usable address. Kept as a single widget so the
 // two routes can't drift apart.
@@ -311,25 +351,14 @@ class _NoAddressActionShellState extends State<_NoAddressActionShell> {
 
   @override
   Widget build(BuildContext context) {
-    return ActionHandlerShell(
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            DAppInfoWidget(
-              title: widget.title,
-              dappUrl: widget.dappUrl,
-              dappTitle: widget.dappTitle,
-              dappFavicon: widget.dappFavicon,
-            ),
-            const Expanded(
-              child: Center(
-                child: Text("No address available in current account"),
-              ),
-            ),
-          ],
+    return _rpcActionScaffold(
+      title: widget.title,
+      dappUrl: widget.dappUrl,
+      dappTitle: widget.dappTitle,
+      dappFavicon: widget.dappFavicon,
+      child: const Expanded(
+        child: Center(
+          child: Text("No address available in current account"),
         ),
       ),
     );
@@ -667,14 +696,7 @@ class AppRouter {
                       dappUrl: action.origin,
                       dappTitle: action.title,
                       dappFavicon: action.favicon,
-                      onError: (error) {
-                        GetIt.I<RPCGetBalanceErrorCallback>()(
-                            RPCErrorCallbackArgs(
-                          tabId: action.tabId,
-                          requestId: action.requestId,
-                          error: error,
-                        ));
-                      },
+                      onError: (error) => _emitRpcError(action, error),
                     );
                   }
 
@@ -683,42 +705,25 @@ class AppRouter {
                             address: address.address,
                             httpConfig: session.httpConfig,
                           ),
-                      child: ActionHandlerShell(
-                          child: Padding(
-                        padding: const EdgeInsets.all(24.0),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            DAppInfoWidget(
-                              title: 'VIEW BALANCE',
-                              dappUrl: action.origin,
-                              dappTitle: action.title,
-                              dappFavicon: action.favicon,
-                            ),
-                            GetBalanceForm(
-                              onSuccess: (confirmed, unconfirmed, total) {
-                                GetIt.I<RPCGetBalanceSuccessCallback>()(
-                                    RPCGetBalanceSuccessCallbackArgs(
-                                  tabId: action.tabId,
-                                  requestId: action.requestId,
-                                  confirmed: confirmed,
-                                  unconfirmed: unconfirmed,
-                                  total: total,
-                                ));
-                              },
-                              onError: (error) {
-                                GetIt.I<RPCGetBalanceErrorCallback>()(
-                                    RPCErrorCallbackArgs(
-                                  tabId: action.tabId,
-                                  requestId: action.requestId,
-                                  error: error,
-                                ));
-                              },
-                            ),
-                          ],
+                      child: _rpcActionScaffold(
+                        title: 'VIEW BALANCE',
+                        dappUrl: action.origin,
+                        dappTitle: action.title,
+                        dappFavicon: action.favicon,
+                        child: GetBalanceForm(
+                          onSuccess: (confirmed, unconfirmed, total) {
+                            GetIt.I<RPCGetBalanceSuccessCallback>()(
+                                RPCGetBalanceSuccessCallbackArgs(
+                              tabId: action.tabId,
+                              requestId: action.requestId,
+                              confirmed: confirmed,
+                              unconfirmed: unconfirmed,
+                              total: total,
+                            ));
+                          },
+                          onError: (error) => _emitRpcError(action, error),
                         ),
-                      )));
+                      ));
                 }),
             GoRoute(
                 path: "/rpc/send-transfer",
@@ -742,14 +747,7 @@ class AppRouter {
                       dappUrl: action.origin,
                       dappTitle: action.title,
                       dappFavicon: action.favicon,
-                      onError: (error) {
-                        GetIt.I<RPCSendTransferErrorCallback>()(
-                            RPCErrorCallbackArgs(
-                          tabId: action.tabId,
-                          requestId: action.requestId,
-                          error: error,
-                        ));
-                      },
+                      onError: (error) => _emitRpcError(action, error),
                     );
                   }
 
@@ -762,45 +760,28 @@ class AppRouter {
                             passwordRequired: GetIt.I<SettingsRepository>()
                                 .requirePasswordForCryptoOperations,
                           ),
-                      child: ActionHandlerShell(
-                          child: Padding(
-                        padding: const EdgeInsets.all(24.0),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            DAppInfoWidget(
-                              title: 'SEND BITCOIN',
-                              dappUrl: action.origin,
-                              dappTitle: action.title,
-                              dappFavicon: action.favicon,
-                            ),
-                            SendTransferForm(
-                              passwordRequired: GetIt.I<SettingsRepository>()
-                                  .requirePasswordForCryptoOperations,
-                              destination: action.destination,
-                              amount: action.amount,
-                              source: source.address,
-                              onSuccess: (txid) {
-                                GetIt.I<RPCSendTransferSuccessCallback>()(
-                                    RPCSendTransferSuccessCallbackArgs(
-                                  tabId: action.tabId,
-                                  requestId: action.requestId,
-                                  txid: txid,
-                                ));
-                              },
-                              onError: (error) {
-                                GetIt.I<RPCSendTransferErrorCallback>()(
-                                    RPCErrorCallbackArgs(
-                                  tabId: action.tabId,
-                                  requestId: action.requestId,
-                                  error: error,
-                                ));
-                              },
-                            ),
-                          ],
+                      child: _rpcActionScaffold(
+                        title: 'SEND BITCOIN',
+                        dappUrl: action.origin,
+                        dappTitle: action.title,
+                        dappFavicon: action.favicon,
+                        child: SendTransferForm(
+                          passwordRequired: GetIt.I<SettingsRepository>()
+                              .requirePasswordForCryptoOperations,
+                          destination: action.destination,
+                          amount: action.amount,
+                          source: source.address,
+                          onSuccess: (txid) {
+                            GetIt.I<RPCSendTransferSuccessCallback>()(
+                                RPCSendTransferSuccessCallbackArgs(
+                              tabId: action.tabId,
+                              requestId: action.requestId,
+                              txid: txid,
+                            ));
+                          },
+                          onError: (error) => _emitRpcError(action, error),
                         ),
-                      )));
+                      ));
                 }),
             GoRoute(
                 path: "/rpc/sign-message-bls",

--- a/lib/presentation/forms/get_balance/bloc/get_balance_bloc.dart
+++ b/lib/presentation/forms/get_balance/bloc/get_balance_bloc.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+
+import 'package:horizon/domain/entities/http_config.dart';
+import 'package:horizon/domain/repositories/bitcoin_repository.dart';
+
+import './get_balance_event.dart';
+import './get_balance_state.dart';
+
+/// Read-only BTC balance lookup for the sats-connect `getBalance` RPC.
+/// Fetches confirmed + unconfirmed sats for [address] from the Esplora-backed
+/// [BitcoinRepository]; no signing or password is involved.
+class GetBalanceBloc extends Bloc<GetBalanceEvent, GetBalanceState> {
+  final String address;
+  final HttpConfig httpConfig;
+  final BitcoinRepository _bitcoinRepository;
+
+  GetBalanceBloc({
+    required this.address,
+    required this.httpConfig,
+    BitcoinRepository? bitcoinRepository,
+  })  : _bitcoinRepository = bitcoinRepository ?? GetIt.I<BitcoinRepository>(),
+        super(const GetBalanceState()) {
+    on<FetchBalance>(_onFetchBalance);
+    add(FetchBalance());
+  }
+
+  Future<void> _onFetchBalance(
+      FetchBalance event, Emitter<GetBalanceState> emit) async {
+    emit(state.copyWith(status: GetBalanceStatus.loading, error: null));
+    try {
+      final info = await _bitcoinRepository.getAddressInfo(
+          address: address, httpConfig: httpConfig);
+      final confirmed =
+          info.chainStats.fundedTxoSum - info.chainStats.spentTxoSum;
+      final unconfirmed =
+          info.mempoolStats.fundedTxoSum - info.mempoolStats.spentTxoSum;
+      emit(state.copyWith(
+        status: GetBalanceStatus.success,
+        confirmed: confirmed,
+        unconfirmed: unconfirmed,
+        total: confirmed + unconfirmed,
+      ));
+    } catch (e) {
+      emit(state.copyWith(
+        status: GetBalanceStatus.failure,
+        error: e.toString(),
+      ));
+    }
+  }
+}

--- a/lib/presentation/forms/get_balance/bloc/get_balance_bloc.dart
+++ b/lib/presentation/forms/get_balance/bloc/get_balance_bloc.dart
@@ -33,6 +33,10 @@ class GetBalanceBloc extends Bloc<GetBalanceEvent, GetBalanceState> {
           address: address, httpConfig: httpConfig);
       final confirmed =
           info.chainStats.fundedTxoSum - info.chainStats.spentTxoSum;
+      // Net mempool delta (Esplora model). Intentionally signed: an address
+      // spending in the mempool funds < spends, so `unconfirmed` is negative
+      // and `total` is the spendable balance net of that pending outflow. Do
+      // not clamp to 0 — it would make `total` inconsistent with the chain.
       final unconfirmed =
           info.mempoolStats.fundedTxoSum - info.mempoolStats.spentTxoSum;
       emit(state.copyWith(

--- a/lib/presentation/forms/get_balance/bloc/get_balance_event.dart
+++ b/lib/presentation/forms/get_balance/bloc/get_balance_event.dart
@@ -1,0 +1,3 @@
+abstract class GetBalanceEvent {}
+
+class FetchBalance extends GetBalanceEvent {}

--- a/lib/presentation/forms/get_balance/bloc/get_balance_state.dart
+++ b/lib/presentation/forms/get_balance/bloc/get_balance_state.dart
@@ -1,0 +1,35 @@
+enum GetBalanceStatus { loading, success, failure }
+
+class GetBalanceState {
+  final GetBalanceStatus status;
+
+  // Balances are in satoshis.
+  final int confirmed;
+  final int unconfirmed;
+  final int total;
+  final String? error;
+
+  const GetBalanceState({
+    this.status = GetBalanceStatus.loading,
+    this.confirmed = 0,
+    this.unconfirmed = 0,
+    this.total = 0,
+    this.error,
+  });
+
+  GetBalanceState copyWith({
+    GetBalanceStatus? status,
+    int? confirmed,
+    int? unconfirmed,
+    int? total,
+    String? error,
+  }) {
+    return GetBalanceState(
+      status: status ?? this.status,
+      confirmed: confirmed ?? this.confirmed,
+      unconfirmed: unconfirmed ?? this.unconfirmed,
+      total: total ?? this.total,
+      error: error ?? this.error,
+    );
+  }
+}

--- a/lib/presentation/forms/get_balance/bloc/get_balance_state.dart
+++ b/lib/presentation/forms/get_balance/bloc/get_balance_state.dart
@@ -1,6 +1,8 @@
 enum GetBalanceStatus { loading, success, failure }
 
 class GetBalanceState {
+  static const _sentinel = Object();
+
   final GetBalanceStatus status;
 
   // Balances are in satoshis.
@@ -22,14 +24,14 @@ class GetBalanceState {
     int? confirmed,
     int? unconfirmed,
     int? total,
-    String? error,
+    Object? error = _sentinel,
   }) {
     return GetBalanceState(
       status: status ?? this.status,
       confirmed: confirmed ?? this.confirmed,
       unconfirmed: unconfirmed ?? this.unconfirmed,
       total: total ?? this.total,
-      error: error ?? this.error,
+      error: error == _sentinel ? this.error : error as String?,
     );
   }
 }

--- a/lib/presentation/forms/get_balance/view/get_balance_form.dart
+++ b/lib/presentation/forms/get_balance/view/get_balance_form.dart
@@ -11,8 +11,12 @@ import 'package:horizon/presentation/forms/get_balance/bloc/get_balance_state.da
 class GetBalanceForm extends StatelessWidget {
   final void Function(String confirmed, String unconfirmed, String total)
       onSuccess;
+  // A balance read can only fail fatally (network/unreachable); there is nothing
+  // to retry, so surface the real error to the dApp and let it close the popup.
+  final void Function(String error) onError;
 
-  const GetBalanceForm({super.key, required this.onSuccess});
+  const GetBalanceForm(
+      {super.key, required this.onSuccess, required this.onError});
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +28,8 @@ class GetBalanceForm extends StatelessWidget {
             state.unconfirmed.toString(),
             state.total.toString(),
           );
+        } else if (state.status == GetBalanceStatus.failure) {
+          onError(state.error ?? 'Failed to fetch balance');
         }
       },
       child: BlocBuilder<GetBalanceBloc, GetBalanceState>(

--- a/lib/presentation/forms/get_balance/view/get_balance_form.dart
+++ b/lib/presentation/forms/get_balance/view/get_balance_form.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:horizon/presentation/forms/get_balance/bloc/get_balance_bloc.dart';
+import 'package:horizon/presentation/forms/get_balance/bloc/get_balance_state.dart';
+
+/// `getBalance` is a read-only request over data that is already public on
+/// chain (and for an address the dApp already learned at connect time), so it
+/// auto-resolves once fetched rather than asking the user to approve a balance
+/// read. The popup shows a brief spinner, then returns the balance and closes.
+class GetBalanceForm extends StatelessWidget {
+  final void Function(String confirmed, String unconfirmed, String total)
+      onSuccess;
+
+  const GetBalanceForm({super.key, required this.onSuccess});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<GetBalanceBloc, GetBalanceState>(
+      listener: (context, state) {
+        if (state.status == GetBalanceStatus.success) {
+          onSuccess(
+            state.confirmed.toString(),
+            state.unconfirmed.toString(),
+            state.total.toString(),
+          );
+        }
+      },
+      child: BlocBuilder<GetBalanceBloc, GetBalanceState>(
+        builder: (context, state) {
+          return Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: switch (state.status) {
+              GetBalanceStatus.failure => Text(
+                  state.error ?? 'Failed to fetch balance',
+                  style: const TextStyle(color: Colors.red),
+                ),
+              _ => const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [CircularProgressIndicator()],
+                ),
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+
+import 'package:horizon/domain/entities/address_v2.dart';
+import 'package:horizon/domain/entities/compose_send.dart';
+import 'package:horizon/domain/entities/http_config.dart';
+import 'package:horizon/domain/repositories/compose_repository.dart';
+import 'package:horizon/domain/usecases/get_fee_estimates.dart';
+import 'package:horizon/presentation/common/password_input.dart';
+import 'package:horizon/presentation/common/usecase/compose_transaction_usecase.dart';
+import 'package:horizon/presentation/common/usecase/sign_and_broadcast_transaction_usecase.dart';
+
+import './send_transfer_event.dart';
+import './send_transfer_state.dart';
+
+/// Drives the sats-connect `sendTransfer` RPC: compose a plain BTC send from
+/// the wallet's payment address, let the user review the fee, then sign and
+/// broadcast on confirmation. The fee rate is picked by the wallet (medium
+/// estimate) since sats-connect's `sendTransfer` carries no fee parameter.
+class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
+  final AddressV2 source;
+  final String destination;
+  final int amount; // satoshis
+  final HttpConfig httpConfig;
+  final bool passwordRequired;
+
+  final GetFeeEstimatesUseCase _getFeeEstimatesUseCase;
+  final ComposeTransactionUseCase _composeTransactionUseCase;
+  final ComposeRepository _composeRepository;
+  final SignAndBroadcastTransactionUseCase _signAndBroadcastTransactionUseCase;
+
+  String? _rawtransaction;
+
+  SendTransferBloc({
+    required this.source,
+    required this.destination,
+    required this.amount,
+    required this.httpConfig,
+    required this.passwordRequired,
+    GetFeeEstimatesUseCase? getFeeEstimatesUseCase,
+    ComposeTransactionUseCase? composeTransactionUseCase,
+    ComposeRepository? composeRepository,
+    SignAndBroadcastTransactionUseCase? signAndBroadcastTransactionUseCase,
+  })  : _getFeeEstimatesUseCase =
+            getFeeEstimatesUseCase ?? GetIt.I<GetFeeEstimatesUseCase>(),
+        _composeTransactionUseCase =
+            composeTransactionUseCase ?? GetIt.I<ComposeTransactionUseCase>(),
+        _composeRepository = composeRepository ?? GetIt.I<ComposeRepository>(),
+        _signAndBroadcastTransactionUseCase =
+            signAndBroadcastTransactionUseCase ??
+                GetIt.I<SignAndBroadcastTransactionUseCase>(),
+        super(const SendTransferState()) {
+    on<ComposeRequested>(_onComposeRequested);
+    on<PasswordChanged>(_onPasswordChanged);
+    on<ConfirmSend>(_onConfirmSend);
+    add(ComposeRequested());
+  }
+
+  void _onPasswordChanged(
+      PasswordChanged event, Emitter<SendTransferState> emit) {
+    emit(state.copyWith(
+      password: PasswordInput.dirty(event.password),
+      status: SendTransferStatus.review,
+    ));
+  }
+
+  Future<void> _onComposeRequested(
+      ComposeRequested event, Emitter<SendTransferState> emit) async {
+    emit(state.copyWith(status: SendTransferStatus.composing));
+
+    final feeResult = await _getFeeEstimatesUseCase
+        .call(GetFeeEstimatesParams(httpConfig: httpConfig))
+        .run();
+
+    final num? feeRate = feeResult.fold((_) => null, (estimates) => estimates.medium);
+    if (feeRate == null) {
+      emit(state.copyWith(
+        status: SendTransferStatus.failure,
+        error: 'Failed to fetch fee estimates',
+      ));
+      return;
+    }
+
+    final composeResult = await _composeTransactionUseCase
+        .callT<ComposeSendParams, ComposeSendResponse>(
+          feeRate: feeRate,
+          source: source.address,
+          params: ComposeSendParams(
+            source: source.address,
+            destination: destination,
+            asset: 'BTC',
+            quantity: amount,
+          ),
+          composeFn: _composeRepository.composeSendVerbose,
+          httpConfig: httpConfig,
+        )
+        .run();
+
+    composeResult.fold(
+      (error) => emit(state.copyWith(
+        status: SendTransferStatus.failure,
+        error: error,
+      )),
+      (resp) {
+        _rawtransaction = resp.rawtransaction;
+        emit(state.copyWith(
+          status: SendTransferStatus.review,
+          feeSats: resp.btcFee,
+        ));
+      },
+    );
+  }
+
+  Future<void> _onConfirmSend(
+      ConfirmSend event, Emitter<SendTransferState> emit) async {
+    final raw = _rawtransaction;
+    if (raw == null) {
+      emit(state.copyWith(
+        status: SendTransferStatus.failure,
+        error: 'Transaction not composed',
+      ));
+      return;
+    }
+
+    emit(state.copyWith(status: SendTransferStatus.broadcasting));
+
+    final decryptionStrategy =
+        passwordRequired ? Password(state.password.value) : InMemoryKey();
+
+    final result = await _signAndBroadcastTransactionUseCase
+        .call(SignAndBroadcastTransactionParams(
+          source: source,
+          decryptionStrategy: decryptionStrategy,
+          rawtransaction: raw,
+          httpConfig: httpConfig,
+        ))
+        .run();
+
+    result.fold(
+      (error) => emit(state.copyWith(
+        status: SendTransferStatus.failure,
+        error: error,
+      )),
+      (broadcast) => emit(state.copyWith(
+        status: SendTransferStatus.success,
+        txid: broadcast.hash,
+      )),
+    );
+  }
+}

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
@@ -66,7 +66,7 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
 
   Future<void> _onComposeRequested(
       ComposeRequested event, Emitter<SendTransferState> emit) async {
-    emit(state.copyWith(status: SendTransferStatus.composing));
+    emit(state.copyWith(status: SendTransferStatus.composing, error: null));
 
     final feeResult = await _getFeeEstimatesUseCase
         .call(GetFeeEstimatesParams(httpConfig: httpConfig))
@@ -122,7 +122,7 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
       return;
     }
 
-    emit(state.copyWith(status: SendTransferStatus.broadcasting));
+    emit(state.copyWith(status: SendTransferStatus.broadcasting, error: null));
 
     final decryptionStrategy =
         passwordRequired ? Password(state.password.value) : InMemoryKey();

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
@@ -83,7 +83,7 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
     final num? feeRate = feeResult.fold((_) => null, (estimates) => estimates.medium);
     if (feeRate == null) {
       emit(state.copyWith(
-        status: SendTransferStatus.failure,
+        status: SendTransferStatus.composeFailure,
         error: 'Failed to fetch fee estimates',
       ));
       return;
@@ -106,7 +106,7 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
 
     composeResult.fold(
       (error) => emit(state.copyWith(
-        status: SendTransferStatus.failure,
+        status: SendTransferStatus.composeFailure,
         error: error,
       )),
       (resp) {
@@ -133,8 +133,10 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
 
     final raw = _rawtransaction;
     if (raw == null) {
+      // No composed transaction to broadcast — treat as a fatal compose failure
+      // so the dApp is notified and the popup closes.
       emit(state.copyWith(
-        status: SendTransferStatus.failure,
+        status: SendTransferStatus.composeFailure,
         error: 'Transaction not composed',
       ));
       return;
@@ -156,7 +158,9 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
 
     result.fold(
       (error) => emit(state.copyWith(
-        status: SendTransferStatus.failure,
+        // Retryable: the transaction is still cached, so keep the popup open and
+        // let the user fix the cause (e.g. password) and resend.
+        status: SendTransferStatus.broadcastFailure,
         error: error,
       )),
       (broadcast) => emit(state.copyWith(

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
@@ -58,6 +58,14 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
 
   void _onPasswordChanged(
       PasswordChanged event, Emitter<SendTransferState> emit) {
+    // Never resurrect the review screen once a broadcast is in flight (or has
+    // succeeded): doing so would re-enable the Confirm button and let a stray
+    // keystroke in the still-mounted password field trigger a second
+    // sign-and-broadcast of the same transaction.
+    if (state.status == SendTransferStatus.broadcasting ||
+        state.status == SendTransferStatus.success) {
+      return;
+    }
     emit(state.copyWith(
       password: PasswordInput.dirty(event.password),
       status: SendTransferStatus.review,

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart
@@ -121,6 +121,16 @@ class SendTransferBloc extends Bloc<SendTransferEvent, SendTransferState> {
 
   Future<void> _onConfirmSend(
       ConfirmSend event, Emitter<SendTransferState> emit) async {
+    // Re-entrancy guard. Bloc's default (concurrent) transformer plus the
+    // window between the first tap and the Confirm button disabling on the
+    // broadcasting state means two ConfirmSend events can race. The cached
+    // `_rawtransaction` would then be broadcast twice, so refuse any confirm
+    // once a broadcast is in flight or has already succeeded.
+    if (state.status == SendTransferStatus.broadcasting ||
+        state.status == SendTransferStatus.success) {
+      return;
+    }
+
     final raw = _rawtransaction;
     if (raw == null) {
       emit(state.copyWith(

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_event.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_event.dart
@@ -1,0 +1,12 @@
+abstract class SendTransferEvent {}
+
+/// Compose the BTC send (fetch fee estimate + build the unsigned transaction).
+class ComposeRequested extends SendTransferEvent {}
+
+class PasswordChanged extends SendTransferEvent {
+  final String password;
+  PasswordChanged(this.password);
+}
+
+/// Sign and broadcast the composed transaction.
+class ConfirmSend extends SendTransferEvent {}

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_state.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_state.dart
@@ -1,7 +1,18 @@
 import 'package:formz/formz.dart';
 import 'package:horizon/presentation/common/password_input.dart';
 
-enum SendTransferStatus { composing, review, broadcasting, success, failure }
+enum SendTransferStatus {
+  composing,
+  review,
+  broadcasting,
+  success,
+  // Fee fetch or compose failed — no transaction was built, so there is nothing
+  // to retry. Surfaced to the dApp and the popup closes.
+  composeFailure,
+  // The broadcast failed (e.g. wrong password, transient node error). The
+  // composed transaction is still cached, so the popup stays open for a retry.
+  broadcastFailure,
+}
 
 class SendTransferState with FormzMixin {
   static const _sentinel = Object();

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_state.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_state.dart
@@ -1,0 +1,41 @@
+import 'package:formz/formz.dart';
+import 'package:horizon/presentation/common/password_input.dart';
+
+enum SendTransferStatus { composing, review, broadcasting, success, failure }
+
+class SendTransferState with FormzMixin {
+  final SendTransferStatus status;
+  final PasswordInput password;
+
+  // Network fee of the composed transaction, in satoshis.
+  final int feeSats;
+  final String? txid;
+  final String? error;
+
+  const SendTransferState({
+    this.status = SendTransferStatus.composing,
+    this.password = const PasswordInput.pure(),
+    this.feeSats = 0,
+    this.txid,
+    this.error,
+  });
+
+  @override
+  List<FormzInput> get inputs => [password];
+
+  SendTransferState copyWith({
+    SendTransferStatus? status,
+    PasswordInput? password,
+    int? feeSats,
+    String? txid,
+    String? error,
+  }) {
+    return SendTransferState(
+      status: status ?? this.status,
+      password: password ?? this.password,
+      feeSats: feeSats ?? this.feeSats,
+      txid: txid ?? this.txid,
+      error: error ?? this.error,
+    );
+  }
+}

--- a/lib/presentation/forms/send_transfer/bloc/send_transfer_state.dart
+++ b/lib/presentation/forms/send_transfer/bloc/send_transfer_state.dart
@@ -4,6 +4,8 @@ import 'package:horizon/presentation/common/password_input.dart';
 enum SendTransferStatus { composing, review, broadcasting, success, failure }
 
 class SendTransferState with FormzMixin {
+  static const _sentinel = Object();
+
   final SendTransferStatus status;
   final PasswordInput password;
 
@@ -27,15 +29,15 @@ class SendTransferState with FormzMixin {
     SendTransferStatus? status,
     PasswordInput? password,
     int? feeSats,
-    String? txid,
-    String? error,
+    Object? txid = _sentinel,
+    Object? error = _sentinel,
   }) {
     return SendTransferState(
       status: status ?? this.status,
       password: password ?? this.password,
       feeSats: feeSats ?? this.feeSats,
-      txid: txid ?? this.txid,
-      error: error ?? this.error,
+      txid: txid == _sentinel ? this.txid : txid as String?,
+      error: error == _sentinel ? this.error : error as String?,
     );
   }
 }

--- a/lib/presentation/forms/send_transfer/view/send_transfer_form.dart
+++ b/lib/presentation/forms/send_transfer/view/send_transfer_form.dart
@@ -15,6 +15,9 @@ class SendTransferForm extends StatefulWidget {
   final int amount; // satoshis
   final String source;
   final void Function(String txid) onSuccess;
+  // Fired only for a fatal compose failure (nothing to retry): the dApp is
+  // notified and the popup closes. Broadcast failures stay on screen for retry.
+  final void Function(String error) onError;
 
   const SendTransferForm({
     super.key,
@@ -23,6 +26,7 @@ class SendTransferForm extends StatefulWidget {
     required this.amount,
     required this.source,
     required this.onSuccess,
+    required this.onError,
   });
 
   @override
@@ -45,6 +49,8 @@ class _SendTransferFormState extends State<SendTransferForm> {
       listener: (context, state) {
         if (state.status == SendTransferStatus.success && state.txid != null) {
           widget.onSuccess(state.txid!);
+        } else if (state.status == SendTransferStatus.composeFailure) {
+          widget.onError(state.error ?? 'Transaction failed');
         }
       },
       child: BlocBuilder<SendTransferBloc, SendTransferState>(
@@ -117,7 +123,8 @@ class _SendTransferFormState extends State<SendTransferForm> {
                   ],
                 ),
                 const SizedBox(height: 16),
-                if (state.status == SendTransferStatus.failure)
+                if (state.status == SendTransferStatus.composeFailure ||
+                    state.status == SendTransferStatus.broadcastFailure)
                   Text(
                     state.error ?? 'Transaction failed',
                     style: const TextStyle(color: Colors.red),

--- a/lib/presentation/forms/send_transfer/view/send_transfer_form.dart
+++ b/lib/presentation/forms/send_transfer/view/send_transfer_form.dart
@@ -81,6 +81,8 @@ class _SendTransferFormState extends State<SendTransferForm> {
                     padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
                     child: HorizonTextField(
                       controller: passwordController,
+                      enabled:
+                          state.status != SendTransferStatus.broadcasting,
                       onChanged: (password) => context
                           .read<SendTransferBloc>()
                           .add(PasswordChanged(password)),

--- a/lib/presentation/forms/send_transfer/view/send_transfer_form.dart
+++ b/lib/presentation/forms/send_transfer/view/send_transfer_form.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:horizon/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart';
+import 'package:horizon/presentation/forms/send_transfer/bloc/send_transfer_state.dart';
+import 'package:horizon/presentation/forms/send_transfer/bloc/send_transfer_event.dart';
+
+import 'package:horizon/presentation/screens/horizon/redesign_ui.dart'
+    as HorizonUI;
+import 'package:horizon/presentation/screens/horizon/redesign_ui.dart';
+
+class SendTransferForm extends StatefulWidget {
+  final bool passwordRequired;
+  final String destination;
+  final int amount; // satoshis
+  final String source;
+  final void Function(String txid) onSuccess;
+
+  const SendTransferForm({
+    super.key,
+    required this.passwordRequired,
+    required this.destination,
+    required this.amount,
+    required this.source,
+    required this.onSuccess,
+  });
+
+  @override
+  State<SendTransferForm> createState() => _SendTransferFormState();
+}
+
+class _SendTransferFormState extends State<SendTransferForm> {
+  final TextEditingController passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return BlocListener<SendTransferBloc, SendTransferState>(
+      listener: (context, state) {
+        if (state.status == SendTransferStatus.success && state.txid != null) {
+          widget.onSuccess(state.txid!);
+        }
+      },
+      child: BlocBuilder<SendTransferBloc, SendTransferState>(
+        builder: (context, state) {
+          if (state.status == SendTransferStatus.composing) {
+            return const Padding(
+              padding: EdgeInsets.all(24.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [CircularProgressIndicator()],
+              ),
+            );
+          }
+
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 12),
+                _row(theme, 'To', widget.destination),
+                const SizedBox(height: 12),
+                _row(theme, 'Amount', '${widget.amount} sats'),
+                const SizedBox(height: 12),
+                _row(theme, 'From', widget.source),
+                const SizedBox(height: 12),
+                _row(theme, 'Network fee',
+                    state.feeSats > 0 ? '${state.feeSats} sats' : '—'),
+                const SizedBox(height: 12),
+                const Divider(),
+                if (widget.passwordRequired)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
+                    child: HorizonTextField(
+                      controller: passwordController,
+                      onChanged: (password) => context
+                          .read<SendTransferBloc>()
+                          .add(PasswordChanged(password)),
+                      hintText: 'Password',
+                      obscureText: true,
+                      errorText: state.password.displayError != null
+                          ? 'Password cannot be empty'
+                          : null,
+                    ),
+                  ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: HorizonUI.HorizonButton(
+                        onPressed: (state.status ==
+                                    SendTransferStatus.broadcasting ||
+                                state.status == SendTransferStatus.success ||
+                                (widget.passwordRequired &&
+                                    !state.password.isValid))
+                            ? null
+                            : () => context
+                                .read<SendTransferBloc>()
+                                .add(ConfirmSend()),
+                        child: state.status == SendTransferStatus.broadcasting
+                            ? HorizonUI.WidgetButtonContent(
+                                value: const CircularProgressIndicator())
+                            : HorizonUI.TextButtonContent(
+                                value: 'Confirm & Send'),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                if (state.status == SendTransferStatus.failure)
+                  Text(
+                    state.error ?? 'Transaction failed',
+                    style: const TextStyle(color: Colors.red),
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _row(ThemeData theme, String label, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: theme.textTheme.labelSmall),
+        const SizedBox(height: 4),
+        SelectableText(value),
+      ],
+    );
+  }
+}

--- a/lib/presentation/forms/sign_psbt/view/sign_psbt_form.dart
+++ b/lib/presentation/forms/sign_psbt/view/sign_psbt_form.dart
@@ -847,7 +847,7 @@ class _SignPsbtFormState extends State<SignPsbtForm> {
                             ),
                             Expanded(
                                 child: Text(
-                                    "A third party has requested that you sign this transaction.  It will not be broadcasted from your wallet, but may be broadcasted by the requesting party.  It is recommended that you verify the transaction inputs and outputs.",
+                                    "A third party requested this signature. Review the details before signing.",
                                     style: Theme.of(context)
                                         .textTheme
                                         .bodySmall!

--- a/lib/presentation/forms/swap_multi_buy_sign_form/swap_multi_buy_sign_form_view.dart
+++ b/lib/presentation/forms/swap_multi_buy_sign_form/swap_multi_buy_sign_form_view.dart
@@ -5,7 +5,7 @@ import 'package:horizon/domain/entities/psbt_type.dart';
 import 'package:horizon/domain/usecases/get_fee_estimates.dart';
 import 'package:horizon/presentation/common/redesign_colors.dart';
 import 'package:horizon/presentation/screens/horizon/redesign_ui.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 import 'package:horizon/domain/entities/http_config.dart';
 import 'package:formz/formz.dart';

--- a/lib/presentation/screens/activity/activity_view.dart
+++ b/lib/presentation/screens/activity/activity_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:timeago_flutter/timeago_flutter.dart';
 import 'package:horizon/utils/app_icons.dart';
 

--- a/lib/presentation/screens/tools/tools_view.dart
+++ b/lib/presentation/screens/tools/tools_view.dart
@@ -6,7 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:horizon/presentation/common/redesign_colors.dart';
 import 'package:horizon/presentation/common/theme_extension.dart';
 import 'package:horizon/utils/app_icons.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:horizon/utils/horizon_market_referral.dart';
 
 class Tool extends StatelessWidget {

--- a/lib/setup.dart
+++ b/lib/setup.dart
@@ -713,6 +713,49 @@ void setup() {
               encryptedBlsPrivateKey: ${args.encryptedBlsPrivateKey}
       """));
 
+  injector.registerLazySingleton<RPCGetBalanceSuccessCallback>(
+      () => config.isWebExtension
+          ? (args) {
+              chrome.tabs.sendMessage(
+                args.tabId,
+                {
+                  "id": args.requestId,
+                  "confirmed": args.confirmed,
+                  "unconfirmed": args.unconfirmed,
+                  "total": args.total,
+                },
+                null,
+              );
+
+              Future.delayed(const Duration(seconds: 0), html.window.close);
+            }
+          : (args) => GetIt.I<Logger>().debug("""
+           RPCGetBalanceSuccessCallback called with:
+              tabId: ${args.tabId}
+              requestId: ${args.requestId}
+              confirmed: ${args.confirmed}
+              unconfirmed: ${args.unconfirmed}
+              total: ${args.total}
+      """));
+
+  injector.registerLazySingleton<RPCSendTransferSuccessCallback>(
+      () => config.isWebExtension
+          ? (args) {
+              chrome.tabs.sendMessage(
+                args.tabId,
+                {"id": args.requestId, "txid": args.txid},
+                null,
+              );
+
+              Future.delayed(const Duration(seconds: 0), html.window.close);
+            }
+          : (args) => GetIt.I<Logger>().debug("""
+           RPCSendTransferSuccessCallback called with:
+              tabId: ${args.tabId}
+              requestId: ${args.requestId}
+              txid: ${args.txid}
+      """));
+
   injector.registerLazySingleton<VersionRepository>(() => config.isWebExtension
       ? VersionRepositoryExtensionImpl(
           config: config, logger: GetIt.I<Logger>())

--- a/lib/setup.dart
+++ b/lib/setup.dart
@@ -756,6 +756,54 @@ void setup() {
               txid: ${args.txid}
       """));
 
+  // Error callbacks for the getBalance / sendTransfer routes. A structured
+  // JSON-RPC error (-32603, internal error) carries the real reason back to the
+  // dApp so it isn't mislabelled as a user rejection (the string-error shape the
+  // background's popup-close handler uses), then closes the popup. Sent before
+  // close, so the provider settles on this error and ignores the later
+  // popup-close rejection — mirroring the success path.
+  injector.registerLazySingleton<RPCGetBalanceErrorCallback>(
+      () => config.isWebExtension
+          ? (args) {
+              chrome.tabs.sendMessage(
+                args.tabId,
+                {
+                  "id": args.requestId,
+                  "error": {"code": -32603, "message": args.error},
+                },
+                null,
+              );
+
+              Future.delayed(const Duration(seconds: 0), html.window.close);
+            }
+          : (args) => GetIt.I<Logger>().debug("""
+           RPCGetBalanceErrorCallback called with:
+              tabId: ${args.tabId}
+              requestId: ${args.requestId}
+              error: ${args.error}
+      """));
+
+  injector.registerLazySingleton<RPCSendTransferErrorCallback>(
+      () => config.isWebExtension
+          ? (args) {
+              chrome.tabs.sendMessage(
+                args.tabId,
+                {
+                  "id": args.requestId,
+                  "error": {"code": -32603, "message": args.error},
+                },
+                null,
+              );
+
+              Future.delayed(const Duration(seconds: 0), html.window.close);
+            }
+          : (args) => GetIt.I<Logger>().debug("""
+           RPCSendTransferErrorCallback called with:
+              tabId: ${args.tabId}
+              requestId: ${args.requestId}
+              error: ${args.error}
+      """));
+
   injector.registerLazySingleton<VersionRepository>(() => config.isWebExtension
       ? VersionRepositoryExtensionImpl(
           config: config, logger: GetIt.I<Logger>())

--- a/lib/setup.dart
+++ b/lib/setup.dart
@@ -756,13 +756,14 @@ void setup() {
               txid: ${args.txid}
       """));
 
-  // Error callbacks for the getBalance / sendTransfer routes. A structured
-  // JSON-RPC error (-32603, internal error) carries the real reason back to the
-  // dApp so it isn't mislabelled as a user rejection (the string-error shape the
-  // background's popup-close handler uses), then closes the popup. Sent before
-  // close, so the provider settles on this error and ignores the later
-  // popup-close rejection — mirroring the success path.
-  injector.registerLazySingleton<RPCGetBalanceErrorCallback>(
+  // Shared error callback for every sats-connect RPC route (getBalance /
+  // sendTransfer / …). A structured JSON-RPC error (-32603, internal error)
+  // carries the real reason back to the dApp so it isn't mislabelled as a user
+  // rejection (the string-error shape the background's popup-close handler
+  // uses), then closes the popup. Sent before close, so the provider settles on
+  // this error and ignores the later popup-close rejection — mirroring the
+  // success path.
+  injector.registerLazySingleton<RPCErrorCallback>(
       () => config.isWebExtension
           ? (args) {
               chrome.tabs.sendMessage(
@@ -777,28 +778,7 @@ void setup() {
               Future.delayed(const Duration(seconds: 0), html.window.close);
             }
           : (args) => GetIt.I<Logger>().debug("""
-           RPCGetBalanceErrorCallback called with:
-              tabId: ${args.tabId}
-              requestId: ${args.requestId}
-              error: ${args.error}
-      """));
-
-  injector.registerLazySingleton<RPCSendTransferErrorCallback>(
-      () => config.isWebExtension
-          ? (args) {
-              chrome.tabs.sendMessage(
-                args.tabId,
-                {
-                  "id": args.requestId,
-                  "error": {"code": -32603, "message": args.error},
-                },
-                null,
-              );
-
-              Future.delayed(const Duration(seconds: 0), html.window.close);
-            }
-          : (args) => GetIt.I<Logger>().debug("""
-           RPCSendTransferErrorCallback called with:
+           RPCErrorCallback called with:
               tabId: ${args.tabId}
               requestId: ${args.requestId}
               error: ${args.error}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1023,14 +1023,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
-  lucide_icons:
+  lucide_icons_flutter:
     dependency: "direct main"
     description:
-      name: lucide_icons
-      sha256: ad24d0fd65707e48add30bebada7d90bff2a1bba0a72d6e9b19d44246b0e83c4
+      name: lucide_icons_flutter
+      sha256: "7c5dc01a32a9905ae34e2d84224e92d6d0c42acf8926df9e01c35a1446bf1b69"
       url: "https://pub.dev"
     source: hosted
-    version: "0.257.0"
+    version: "3.1.14+2"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,7 +92,7 @@ dependencies:
   flutter_inappwebview: ^6.0.0
   meilisearch: ^0.17.0
   group_button: ^5.3.4
-  lucide_icons: ^0.257.0
+  lucide_icons_flutter: ^3.1.14
   auto_size_text: ^3.0.0
   intl: ^0.20.2
   infinite_scroll_pagination: ^5.1.1

--- a/test/action_repository_impl_test.dart
+++ b/test/action_repository_impl_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:horizon/domain/entities/asset_quantity.dart';
 import "package:horizon/common/constants.dart";
@@ -1130,6 +1129,123 @@ void main() {
           expect(action.favicon, favicon);
         },
       );
+    });
+  });
+
+  group(RPCGetBalanceAction, () {
+    test('should decode a valid RPCGetBalanceAction with an explicit address',
+        () {
+      // Arrange
+      const encodedString =
+          'getBalance,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico,bc1qtest';
+
+      // Act
+      final result = actionRepository.fromString(encodedString);
+
+      // Assert
+      expect(result.isRight(), true);
+      result.match(
+        (l) => fail('Expected Right but got Left: $l'),
+        (r) {
+          expect(r, isA<RPCGetBalanceAction>());
+          final action = r as RPCGetBalanceAction;
+          expect(action.tabId, 1);
+          expect(action.requestId, 'def');
+          expect(action.origin, 'https://example.com');
+          expect(action.title, 'Example Site');
+          expect(action.favicon, 'https://example.com/favicon.ico');
+          expect(action.address, 'bc1qtest');
+        },
+      );
+    });
+
+    test(
+        'should decode RPCGetBalanceAction with an empty address as null (sats-connect default)',
+        () {
+      // Arrange: the sats-connect `getBalance` carries no address, so the
+      // provider sends an empty address field, which must resolve to null.
+      const encodedString =
+          'getBalance,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico,';
+
+      // Act
+      final result = actionRepository.fromString(encodedString);
+
+      // Assert
+      expect(result.isRight(), true);
+      result.match(
+        (l) => fail('Expected Right but got Left: $l'),
+        (r) {
+          final action = r as RPCGetBalanceAction;
+          expect(action.address, isNull);
+        },
+      );
+    });
+
+    test('should fail when field count is wrong (6 fields)', () {
+      // Arrange
+      const encodedString =
+          'getBalance,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico';
+
+      // Act
+      final result = actionRepository.fromString(encodedString);
+
+      // Assert
+      expect(result.isLeft(), true);
+    });
+  });
+
+  group(RPCSendTransferAction, () {
+    test('should decode a valid RPCSendTransferAction', () {
+      // Arrange
+      const encodedString =
+          'sendTransfer,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico,bc1qdest,100000';
+
+      // Act
+      final result = actionRepository.fromString(encodedString);
+
+      // Assert
+      expect(result.isRight(), true);
+      result.match(
+        (l) => fail('Expected Right but got Left: $l'),
+        (r) {
+          expect(r, isA<RPCSendTransferAction>());
+          final action = r as RPCSendTransferAction;
+          expect(action.tabId, 1);
+          expect(action.requestId, 'def');
+          expect(action.origin, 'https://example.com');
+          expect(action.title, 'Example Site');
+          expect(action.favicon, 'https://example.com/favicon.ico');
+          expect(action.destination, 'bc1qdest');
+          expect(action.amount, 100000);
+        },
+      );
+    });
+
+    test('should fail when amount is not a positive integer', () {
+      // Arrange
+      const zeroAmount =
+          'sendTransfer,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico,bc1qdest,0';
+      const negativeAmount =
+          'sendTransfer,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico,bc1qdest,-5';
+      const nonNumericAmount =
+          'sendTransfer,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico,bc1qdest,abc';
+
+      // Act + Assert
+      expect(actionRepository.fromString(zeroAmount).isLeft(), true);
+      expect(actionRepository.fromString(negativeAmount).isLeft(), true);
+      expect(actionRepository.fromString(nonNumericAmount).isLeft(), true);
+    });
+
+    test('should fail when field count is wrong (7 fields)', () {
+      // Arrange
+      const encodedString =
+          'sendTransfer,1,def,https%3A%2F%2Fexample.com,Example%20Site,https%3A%2F%2Fexample.com%2Ffavicon.ico,bc1qdest';
+
+      // Act
+      final result = actionRepository.fromString(encodedString);
+
+      // Assert
+      expect(result.isLeft(), true);
     });
   });
 }

--- a/test/send_transfer_bloc_test.dart
+++ b/test/send_transfer_bloc_test.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:horizon/domain/entities/address_v2.dart';
+import 'package:horizon/domain/entities/compose_send.dart';
+import 'package:horizon/domain/entities/fee_estimates.dart';
+import 'package:horizon/domain/entities/http_config.dart';
+import 'package:horizon/domain/repositories/compose_repository.dart';
+import 'package:horizon/domain/usecases/get_fee_estimates.dart';
+import 'package:horizon/presentation/common/usecase/compose_transaction_usecase.dart';
+import 'package:horizon/presentation/common/usecase/sign_and_broadcast_transaction_usecase.dart';
+import 'package:horizon/presentation/forms/send_transfer/bloc/send_transfer_bloc.dart';
+import 'package:horizon/presentation/forms/send_transfer/bloc/send_transfer_event.dart';
+import 'package:horizon/presentation/forms/send_transfer/bloc/send_transfer_state.dart';
+
+class MockGetFeeEstimatesUseCase extends Mock
+    implements GetFeeEstimatesUseCase {}
+
+class MockComposeTransactionUseCase extends Mock
+    implements ComposeTransactionUseCase {}
+
+class MockComposeRepository extends Mock implements ComposeRepository {}
+
+class MockSignAndBroadcastTransactionUseCase extends Mock
+    implements SignAndBroadcastTransactionUseCase {}
+
+class MockComposeSendResponse extends Mock implements ComposeSendResponse {}
+
+class MockAddressV2 extends Mock implements AddressV2 {}
+
+void main() {
+  late MockGetFeeEstimatesUseCase mockGetFeeEstimatesUseCase;
+  late MockComposeTransactionUseCase mockComposeTransactionUseCase;
+  late MockComposeRepository mockComposeRepository;
+  late MockSignAndBroadcastTransactionUseCase
+      mockSignAndBroadcastTransactionUseCase;
+  late MockComposeSendResponse mockComposeSendResponse;
+  late MockAddressV2 mockSource;
+  // Shared gate between build() and act() for the re-entrancy test.
+  late Completer<void> broadcastGate;
+
+  final httpConfig = HttpConfig.mainnet();
+  const feeEstimates = FeeEstimates(fast: 5, medium: 3, slow: 1);
+
+  setUpAll(() {
+    registerFallbackValue(GetFeeEstimatesParams(httpConfig: httpConfig));
+    registerFallbackValue(ComposeSendParams(
+      source: 'bc1qsource',
+      destination: 'bc1qdest',
+      asset: 'BTC',
+      quantity: 1,
+    ));
+    // mocktail resolves `any(named: 'composeFn')` by an `is ComposeFunction`
+    // check; this lambda's reified type satisfies it, so no annotation/cast is
+    // needed.
+    registerFallbackValue(
+        (fee, inputs, params, cfg) async => MockComposeSendResponse());
+    registerFallbackValue(SignAndBroadcastTransactionParams(
+      source: MockAddressV2(),
+      decryptionStrategy: InMemoryKey(),
+      rawtransaction: 'raw',
+      httpConfig: httpConfig,
+    ));
+    registerFallbackValue(httpConfig);
+  });
+
+  setUp(() {
+    mockGetFeeEstimatesUseCase = MockGetFeeEstimatesUseCase();
+    mockComposeTransactionUseCase = MockComposeTransactionUseCase();
+    mockComposeRepository = MockComposeRepository();
+    mockSignAndBroadcastTransactionUseCase =
+        MockSignAndBroadcastTransactionUseCase();
+    mockComposeSendResponse = MockComposeSendResponse();
+    mockSource = MockAddressV2();
+
+    when(() => mockSource.address).thenReturn('bc1qsource');
+    when(() => mockComposeSendResponse.rawtransaction).thenReturn('rawtxhex');
+    when(() => mockComposeSendResponse.btcFee).thenReturn(250);
+  });
+
+  SendTransferBloc buildBloc() => SendTransferBloc(
+        source: mockSource,
+        destination: 'bc1qdest',
+        amount: 100000,
+        httpConfig: httpConfig,
+        // No password so the Confirm path doesn't depend on form input.
+        passwordRequired: false,
+        getFeeEstimatesUseCase: mockGetFeeEstimatesUseCase,
+        composeTransactionUseCase: mockComposeTransactionUseCase,
+        composeRepository: mockComposeRepository,
+        signAndBroadcastTransactionUseCase:
+            mockSignAndBroadcastTransactionUseCase,
+      );
+
+  void stubComposeSucceeds() {
+    when(() => mockGetFeeEstimatesUseCase.call(any()))
+        .thenAnswer((_) => TaskEither.right(feeEstimates));
+    when(() => mockComposeTransactionUseCase
+            .callT<ComposeSendParams, ComposeSendResponse>(
+          feeRate: any(named: 'feeRate'),
+          source: any(named: 'source'),
+          params: any(named: 'params'),
+          composeFn: any(named: 'composeFn'),
+          httpConfig: any(named: 'httpConfig'),
+        )).thenAnswer((_) => TaskEither.right(mockComposeSendResponse));
+  }
+
+  group('SendTransferBloc re-entrancy', () {
+    blocTest<SendTransferBloc, SendTransferState>(
+      'broadcasts exactly once when ConfirmSend fires twice',
+      build: () {
+        stubComposeSucceeds();
+        // Gate the broadcast so both ConfirmSend events are processed while the
+        // first is still in flight (status == broadcasting). Without the guard
+        // the cached transaction would be signed and broadcast twice.
+        broadcastGate = Completer<void>();
+        when(() => mockSignAndBroadcastTransactionUseCase.call(any()))
+            .thenAnswer((_) => TaskEither(() async {
+                  await broadcastGate.future;
+                  return Either<String, BroadcastResponse>.right(
+                      const BroadcastResponse(hex: 'h', hash: 'txhash'));
+                }));
+        return buildBloc();
+      },
+      act: (bloc) async {
+        // Wait for the auto-compose to settle into review.
+        await bloc.stream
+            .firstWhere((s) => s.status == SendTransferStatus.review);
+        bloc.add(ConfirmSend());
+        bloc.add(ConfirmSend());
+        // Let both events be processed while the broadcast is gated.
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        broadcastGate.complete();
+      },
+      wait: const Duration(milliseconds: 50),
+      verify: (_) {
+        verify(() => mockSignAndBroadcastTransactionUseCase.call(any()))
+            .called(1);
+      },
+    );
+
+    blocTest<SendTransferBloc, SendTransferState>(
+      'ignores ConfirmSend after a successful broadcast',
+      build: () {
+        stubComposeSucceeds();
+        when(() => mockSignAndBroadcastTransactionUseCase.call(any()))
+            .thenAnswer((_) => TaskEither.right(
+                const BroadcastResponse(hex: 'h', hash: 'txhash')));
+        return buildBloc();
+      },
+      act: (bloc) async {
+        await bloc.stream
+            .firstWhere((s) => s.status == SendTransferStatus.review);
+        bloc.add(ConfirmSend());
+        await bloc.stream
+            .firstWhere((s) => s.status == SendTransferStatus.success);
+        // A late confirm (e.g. a stray re-tap) must not re-broadcast.
+        bloc.add(ConfirmSend());
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      },
+      wait: const Duration(milliseconds: 50),
+      verify: (_) {
+        verify(() => mockSignAndBroadcastTransactionUseCase.call(any()))
+            .called(1);
+      },
+    );
+  });
+
+  group('SendTransferBloc failure classification', () {
+    blocTest<SendTransferBloc, SendTransferState>(
+      'emits composeFailure (fatal) when compose fails',
+      build: () {
+        when(() => mockGetFeeEstimatesUseCase.call(any()))
+            .thenAnswer((_) => TaskEither.right(feeEstimates));
+        when(() => mockComposeTransactionUseCase
+                .callT<ComposeSendParams, ComposeSendResponse>(
+              feeRate: any(named: 'feeRate'),
+              source: any(named: 'source'),
+              params: any(named: 'params'),
+              composeFn: any(named: 'composeFn'),
+              httpConfig: any(named: 'httpConfig'),
+            )).thenAnswer((_) => TaskEither.left('insufficient funds'));
+        return buildBloc();
+      },
+      wait: const Duration(milliseconds: 50),
+      expect: () => [
+        isA<SendTransferState>()
+            .having((s) => s.status, 'status', SendTransferStatus.composing),
+        isA<SendTransferState>()
+            .having(
+                (s) => s.status, 'status', SendTransferStatus.composeFailure)
+            .having((s) => s.error, 'error', 'insufficient funds'),
+      ],
+      verify: (_) {
+        verifyNever(() => mockSignAndBroadcastTransactionUseCase.call(any()));
+      },
+    );
+
+    blocTest<SendTransferBloc, SendTransferState>(
+      'emits broadcastFailure (retryable) when broadcast fails',
+      build: () {
+        stubComposeSucceeds();
+        when(() => mockSignAndBroadcastTransactionUseCase.call(any()))
+            .thenAnswer((_) => TaskEither.left('node unreachable'));
+        return buildBloc();
+      },
+      act: (bloc) async {
+        await bloc.stream
+            .firstWhere((s) => s.status == SendTransferStatus.review);
+        bloc.add(ConfirmSend());
+      },
+      wait: const Duration(milliseconds: 50),
+      verify: (bloc) {
+        expect(bloc.state.status, SendTransferStatus.broadcastFailure);
+        expect(bloc.state.error, 'node unreachable');
+      },
+    );
+  });
+}

--- a/web/background.js
+++ b/web/background.js
@@ -34,10 +34,20 @@ function encodeTransactionInfo(transactionInfo) {
 }
 
 function listenForPopupClose(args) {
-  chrome.windows.onRemoved.addListener((winId) => {
-    if (winId !== args.id || args.tabId == null) return;
-    chrome.tabs.sendMessage(args.tabId, args.response);
-  });
+  // Nothing to watch if the popup failed to open.
+  if (args.id == null) return;
+  const handler = (winId) => {
+    if (winId !== args.id) return;
+    // Our popup closed: detach this listener before doing anything else.
+    // Without removal every RPC call would leak a permanent onRemoved listener
+    // (they accumulate for the life of the service worker). Only the matching
+    // window's close removes it, so unrelated popups keep their own listeners.
+    chrome.windows.onRemoved.removeListener(handler);
+    if (args.tabId != null) {
+      chrome.tabs.sendMessage(args.tabId, args.response);
+    }
+  };
+  chrome.windows.onRemoved.addListener(handler);
 }
 
 function popup(options) {

--- a/web/background.js
+++ b/web/background.js
@@ -291,6 +291,63 @@ async function rpcExportEncryptedBlsPrivateKey(requestId, port, address) {
   });
 }
 
+async function rpcGetBalance(requestId, port, address) {
+  const origin = getOriginFromPort(port);
+  const tabId = getTabIdFromPort(port);
+  const metadata = await getTabMetadata(tabId);
+
+  const params = [
+    "getBalance",
+    tabId,
+    requestId,
+    encodeURIComponent(origin ?? ""),
+    encodeFreeText(metadata.title),
+    encodeFreeText(metadata.favicon),
+    encodeFreeText(address || ""),
+  ];
+
+  const window = await popup({
+    url: `/index.html#?action=${params.join(",")}`,
+  });
+  listenForPopupClose({
+    id: window?.id,
+    tabId: tabId,
+    response: {
+      id: requestId,
+      error: "User rejected `getBalance` request",
+    },
+  });
+}
+
+async function rpcSendTransfer(requestId, port, destination, amount) {
+  const origin = getOriginFromPort(port);
+  const tabId = getTabIdFromPort(port);
+  const metadata = await getTabMetadata(tabId);
+
+  const params = [
+    "sendTransfer",
+    tabId,
+    requestId,
+    encodeURIComponent(origin ?? ""),
+    encodeFreeText(metadata.title),
+    encodeFreeText(metadata.favicon),
+    encodeFreeText(destination || ""),
+    amount, // integer (satoshis), URL-safe as-is
+  ];
+
+  const window = await popup({
+    url: `/index.html#?action=${params.join(",")}`,
+  });
+  listenForPopupClose({
+    id: window?.id,
+    tabId: tabId,
+    response: {
+      id: requestId,
+      error: "User rejected `sendTransfer` request",
+    },
+  });
+}
+
 async function rpcMessageHandler(message, port) {
   const method = message["method"];
   const tabId = getTabIdFromPort(port);
@@ -341,6 +398,21 @@ async function rpcMessageHandler(message, port) {
         message["id"],
         port,
         message["params"]?.["address"],
+      );
+      break;
+    case "getBalance":
+      await rpcGetBalance(
+        message["id"],
+        port,
+        message["params"]?.["address"],
+      );
+      break;
+    case "sendTransfer":
+      await rpcSendTransfer(
+        message["id"],
+        port,
+        message["params"]?.["destination"],
+        message["params"]?.["amount"],
       );
       break;
     default:

--- a/web/content-script.js
+++ b/web/content-script.js
@@ -7,6 +7,8 @@ const VALID_METHODS = [
   "signMessageBLS",
   "getBLSPoP",
   "exportEncryptedBlsPrivateKey",
+  "getBalance",
+  "sendTransfer",
   "fairmint",
   "dispense",
   "openOrder",
@@ -173,6 +175,31 @@ const methodValidators = {
     return errors;
   },
 
+  getBalance: (msg) => {
+    const errors = [];
+    if (msg.params?.address !== undefined && typeof msg.params.address !== "string") {
+      errors.push(
+        "Invalid 'address' parameter for 'getBalance'. Expected a string.",
+      );
+    }
+    return errors;
+  },
+
+  sendTransfer: (msg) => {
+    const errors = [];
+    if (!msg.params?.destination || typeof msg.params.destination !== "string") {
+      errors.push(
+        "Missing or invalid 'destination' parameter for 'sendTransfer'. Expected a string.",
+      );
+    }
+    if (!Number.isInteger(msg.params?.amount) || msg.params.amount <= 0) {
+      errors.push(
+        "Missing or invalid 'amount' parameter for 'sendTransfer'. Expected a positive integer (satoshis).",
+      );
+    }
+    return errors;
+  },
+
   dispense: (msg) => {
     const errors = ["This is no longer supported.  Please use horizon tool."];
     return errors;
@@ -232,12 +259,51 @@ document.addEventListener("horizon-provider-request", (event) => {
   sendMessageToBackground({ source: MESSAGE_SOURCE, ...event.detail });
 });
 
-function addProviderToPage() {
+// Per-origin map of the last approved connection: { [origin]: { addresses, network } }.
+const CONNECTION_STORE_KEY = "horizonConnections";
+
+async function addProviderToPage() {
   const inpage = document.createElement("script");
   inpage.src = chrome.runtime.getURL("horizon-provider.js");
   inpage.id = "horizon-wallet-provider";
+  // Surface the extension version to the page-world provider (which has no
+  // chrome.runtime access) so `getInfo` can report it.
+  try {
+    inpage.dataset.walletVersion = chrome.runtime.getManifest().version;
+  } catch (e) {
+    // best-effort; provider falls back to "0.0.0"
+  }
+  // Seed the previously-approved connection for this origin so the provider can
+  // answer wallet_getAccount / getNetwork silently (no popup) across reloads.
+  // Awaited before append so the dataset is set before the script executes.
+  try {
+    const store = await chrome.storage.local.get(CONNECTION_STORE_KEY);
+    const conn = store?.[CONNECTION_STORE_KEY]?.[window.location.origin];
+    if (conn) inpage.dataset.horizonConnection = JSON.stringify(conn);
+  } catch (e) {
+    // best-effort; provider just won't have a cached connection
+  }
   document.body.appendChild(inpage);
 }
+
+// Persist (or clear) the approved connection on behalf of the page-world
+// provider, which cannot reach chrome.storage. Keyed strictly by the page's own
+// origin, so a page can only read/write its own entry.
+document.addEventListener("horizon-provider-persist", async (event) => {
+  try {
+    const origin = window.location.origin;
+    const store = await chrome.storage.local.get(CONNECTION_STORE_KEY);
+    const map = store?.[CONNECTION_STORE_KEY] || {};
+    if (event.detail) {
+      map[origin] = event.detail;
+    } else {
+      delete map[origin];
+    }
+    await chrome.storage.local.set({ [CONNECTION_STORE_KEY]: map });
+  } catch (e) {
+    // best-effort; silent retrieval just won't persist across reloads
+  }
+});
 
 document.onreadystatechange = () => {
   if (document.readyState === "complete") {

--- a/web/content-script.js
+++ b/web/content-script.js
@@ -289,20 +289,29 @@ async function addProviderToPage() {
 // Persist (or clear) the approved connection on behalf of the page-world
 // provider, which cannot reach chrome.storage. Keyed strictly by the page's own
 // origin, so a page can only read/write its own entry.
-document.addEventListener("horizon-provider-persist", async (event) => {
-  try {
-    const origin = window.location.origin;
-    const store = await chrome.storage.local.get(CONNECTION_STORE_KEY);
-    const map = store?.[CONNECTION_STORE_KEY] || {};
-    if (event.detail) {
-      map[origin] = event.detail;
-    } else {
-      delete map[origin];
+//
+// chrome.storage read-modify-write is not atomic, so events fired in quick
+// succession (e.g. wallet_connect immediately followed by wallet_disconnect)
+// could read the same pre-state and clobber each other. Serialise every write
+// through a single promise chain so they apply in order.
+let _persistChain = Promise.resolve();
+document.addEventListener("horizon-provider-persist", (event) => {
+  const detail = event.detail;
+  _persistChain = _persistChain.then(async () => {
+    try {
+      const origin = window.location.origin;
+      const store = await chrome.storage.local.get(CONNECTION_STORE_KEY);
+      const map = store?.[CONNECTION_STORE_KEY] || {};
+      if (detail) {
+        map[origin] = detail;
+      } else {
+        delete map[origin];
+      }
+      await chrome.storage.local.set({ [CONNECTION_STORE_KEY]: map });
+    } catch (e) {
+      // best-effort; silent retrieval just won't persist across reloads
     }
-    await chrome.storage.local.set({ [CONNECTION_STORE_KEY]: map });
-  } catch (e) {
-    // best-effort; silent retrieval just won't persist across reloads
-  }
+  });
 });
 
 document.onreadystatechange = () => {

--- a/web/horizon-provider.js
+++ b/web/horizon-provider.js
@@ -1,36 +1,434 @@
+// The content script (which has chrome.runtime access) injects data onto this
+// injected <script> element's dataset; the page world cannot read chrome.runtime
+// itself. Captured once here because `document.currentScript` is only valid
+// during the script's initial synchronous execution.
+const _injectedScript = document.currentScript;
+const WALLET_VERSION =
+  (_injectedScript &&
+    _injectedScript.dataset &&
+    _injectedScript.dataset.walletVersion) ||
+  "0.0.0";
+
+// Methods advertised to provider discovery (WBIP004 `window.btc_providers`)
+// and returned by `getInfo`. These are the sats-connect method names this
+// provider understands; they are translated onto the wallet's house RPC below.
+const SATS_CONNECT_METHODS = [
+  "getAccounts",
+  "getAddresses",
+  "wallet_connect",
+  "wallet_getAccount",
+  "wallet_disconnect",
+  "wallet_getNetwork",
+  "getNetwork",
+  "getInfo",
+  "signMessage",
+  "signPsbt",
+  "sendTransfer",
+  "getBalance",
+];
+
 function registerProvider() {
   if (!window.btc_providers) window.btc_providers = [];
 
   window.btc_providers.push({
     id: "HorizonWalletProvider",
     name: "Horizon Wallet",
-    icon: "data:image/svg;base64,CjxyZWN0IHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4IiByeD0iMjYuODM4NyIgZmlsbD0iIzEyMTAwRiIvPgo8cGF0aCBkPSJNNzQuOTE3MSA1Mi43MTE0QzgyLjQ3NjYgNTEuNTQwOCA5My40MDg3IDQzLjU4MDQgOTMuNDA4NyAzNy4zNzYxQzkzLjQwODcgMzUuNTAzMSA5MS44OTY4IDM0LjIxNTQgODkuNjg3MSAzNC4yMTU0Qzg1LjUwMDQgMzQuMjE1NCA3OC40MDYxIDQwLjUzNjggNzQuOTE3MSA1Mi43MTE0Wk0zOS45MTEgODMuNDk5MUMzMC4wMjU2IDgzLjQ5OTEgMjkuMjExNSA5My4zMzI0IDM5LjA5NjkgOTMuMzMyNEM0My41MTYzIDkzLjMzMjQgNDguODY2MSA5MS41NzY0IDUxLjY1NzMgODguNDE1N0M0Ny41ODY4IDg0LjkwMzggNDQuMjE0MSA4My40OTkxIDM5LjkxMSA4My40OTkxWk0xMDIuODI5IDc5LjI4NDhDMTAzLjQxIDk1Ljc5MDcgOTUuMDM2OSAxMDUuMDM5IDgwLjg0ODQgMTA1LjAzOUM3Mi40NzQ4IDEwNS4wMzkgNjguMjg4MSAxMDEuODc4IDU5LjMzMyA5Ni4wMjQ4QzU0LjY4MSAxMDEuMTc2IDQ1Ljg0MjMgMTA1LjAzOSAzOC41MTU0IDEwNS4wMzlDMTMuMjc4NSAxMDUuMDM5IDE0LjMyNTIgNzIuODQ2MyA0MC4wMjczIDcyLjg0NjNDNDUuMzc3MSA3Mi44NDYzIDQ5LjkxMjggNzQuMjUxMSA1NS43Mjc3IDc3Ljg4TDU5LjU2NTYgNjQuNDE3N0M0My43NDg5IDYwLjA4NjQgMzUuODQwNSA0Ny45MTE4IDQzLjYzMjYgMzAuNDY5M0g1Ni4xOTI5QzQ5LjIxNSA0Mi4wNTg2IDUzLjk4MzIgNTEuNjU3OCA2Mi44MjIgNTIuNzExNEM2Ny41OTAzIDM1LjczNzIgNzcuODI0NiAyMi",
-    methods: ["getAddresses", "signPsbt", "signMessage"],
+    icon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4IiB2aWV3Qm94PSIwIDAgMTI4IDEyOCIgZmlsbD0ibm9uZSI+CjxyZWN0IHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4IiByeD0iMjYuODM4NyIgZmlsbD0iIzEyMTAwRiIvPgo8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyOCAyNikgc2NhbGUoMC42NikiPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTU4LjQ4NzYgNzMuMjNDNjMuODI2MiA3Mi4xMDMxIDcwLjg2OTcgNzAuNjE2NCA3OC4wNzIyIDY2LjkxNzhWMTE2SDEwOUwxMDkgMEg3OC4wNzIyQzc4LjA3MjIgMjAuNzU5OSA3NC4yOTk1IDMwLjMxNjEgNjguNDIxOSAzNi4wMTM0QzY0LjUyMDIgMzkuNzk1NSA2MC4yMDE2IDQxLjAwNzQgNTEuMzA3NyA0Mi44OTQ3QzUxLjAzODYgNDIuOTUxOCA1MC43NjQ2IDQzLjAwOTYgNTAuNDg2IDQzLjA2ODRDNDUuMTYzMSA0NC4xOTE3IDM4LjE0MjIgNDUuNjczNSAzMC45NjExIDQ5LjM1MTRWMEgwLjAzMzM2NUwwLjAzMzM2MzcgMTExLjc3QzAuMDEwNDM0OCAxMTMuMTU3IDAgMTE0LjU2NyAwIDExNkgwLjAzMzM2MzdIMzAuOTI3OEgzMC45NjExVjExMi4wOThDMzEuMTI1MSAxMDIuOTU0IDMxLjg5MTggOTcuMDc3OSAzMy4yMjc4IDkyLjY0MTRDMzQuNTY4OSA4OC4xODc1IDM2LjY5MTQgODQuNDk4MyA0MC44MjIgODAuMDM2OUM0NC42NSA3Ni40NDc2IDQ4Ljk2MjEgNzUuMjUwNiA1Ny42Nzg3IDczLjQwMTFDNTcuOTQzNyA3My4zNDQ4IDU4LjIxMzQgNzMuMjg3OSA1OC40ODc2IDczLjIzWiIgZmlsbD0idXJsKCNob3Jpem9uSCkiLz4KPC9nPgo8ZGVmcz4KPGxpbmVhckdyYWRpZW50IGlkPSJob3Jpem9uSCIgeDE9IjIwIiB5MT0iMTQiIHgyPSIxMDQiIHkyPSIxMjAiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KPHN0b3Agc3RvcC1jb2xvcj0iI0RGRDlCRiIvPgo8c3RvcCBvZmZzZXQ9IjAuMTI1IiBzdG9wLWNvbG9yPSIjRUVEMDlBIi8+CjxzdG9wIG9mZnNldD0iMC4yNTUiIHN0b3AtY29sb3I9IiNFRUIzOTUiLz4KPHN0b3Agb2Zmc2V0PSIwLjQwNSIgc3RvcC1jb2xvcj0iI0U5QTdBRiIvPgo8c3RvcCBvZmZzZXQ9IjAuNjA1IiBzdG9wLWNvbG9yPSIjOUI4NkQ3Ii8+CjxzdG9wIG9mZnNldD0iMC44MTUiIHN0b3AtY29sb3I9IiM1MDlGQzAiLz4KPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjN0RDMkJDIi8+CjwvbGluZWFyR3JhZGllbnQ+CjwvZGVmcz4KPC9zdmc+Cg==",
+    methods: SATS_CONNECT_METHODS,
   });
 }
 
 registerProvider();
 
+// ---------------------------------------------------------------------------
+// Low-level transport to the Horizon Wallet extension (the "house" RPC).
+//
+// Behaviour is intentionally identical to the historical provider.request:
+//   - resolves { result: <response> } on success
+//   - rejects  <response> (the raw message, an error envelope) on failure
+// House-API consumers (e.g. Horizon Market's WalletHorizon) depend on this
+// exact shape, so it must not change.
+// ---------------------------------------------------------------------------
+function houseTransport(method, params) {
+  const id = crypto.randomUUID();
+  const rpcRequest = { jsonrpc: "2.0", id, method, params };
+  document.dispatchEvent(
+    new CustomEvent("horizon-provider-request", { detail: rpcRequest }),
+  );
+  return new Promise((resolve, reject) => {
+    function handleMessage(event) {
+      const response = event.data;
+      if (!response || response.id != id) return;
+      window.removeEventListener("message", handleMessage);
+      if ("error" in response) return reject(response);
+      return resolve({ result: response });
+    }
+    window.addEventListener("message", handleMessage);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// sats-connect compatibility layer.
+//
+// sats-connect providers (per WBIP / @sats-connect/core) are driven through
+// `provider.request(method, params)` and must return a JSON-RPC 2.0 envelope
+// ({ jsonrpc:"2.0", id, result } | { jsonrpc:"2.0", id, error }), *resolving*
+// errors rather than throwing. The wallet's house RPC instead speaks
+// getAddresses (no params), signPsbt ({hex}), signMessage ({message,address})
+// and rejects on error. This layer translates between the two entirely in the
+// page world — the extension's content-script / background / Dart code is
+// untouched.
+//
+// Dispatch is by params so the house API keeps working byte-for-byte:
+//   - getAddresses with `purposes` -> sats-connect ; without -> house
+//   - signPsbt    with `psbt`      -> sats-connect ; with `hex` -> house
+//   - signMessage: success is always a JSON-RPC envelope (still readable as
+//     res.result.signature by house callers); on error it rejects (house)
+//     unless the caller passed `protocol` (a sats-connect-only field).
+// ---------------------------------------------------------------------------
+const RPC_ERROR = {
+  INVALID_PARAMS: -32602,
+  INTERNAL: -32603,
+  METHOD_NOT_FOUND: -32601,
+  USER_REJECTION: -32000,
+  METHOD_NOT_SUPPORTED: -32001,
+  ACCESS_DENIED: -32002,
+};
+
+// house Network enum name -> sats-connect BitcoinNetworkType
+const BITCOIN_NETWORK = {
+  mainnet: "Mainnet",
+  testnet4: "Testnet4",
+  testnet: "Testnet",
+  signet: "Signet",
+  regtest: "Regtest",
+};
+
+// Connection state (the account the user approved for this origin). Seeded at
+// load from chrome.storage — injected by the content script via the script's
+// dataset — so a previously-connected dApp can read its account/network
+// silently (no popup) across page reloads. Updated on every approved
+// getAddresses / wallet_connect.
+let connectedAccount = null; // { addresses: [...all purposes], network: <name> }
+let cachedNetwork = null; // house Network enum name; drives getNetwork
+try {
+  const seed =
+    _injectedScript &&
+    _injectedScript.dataset &&
+    _injectedScript.dataset.horizonConnection;
+  if (seed) {
+    const parsed = JSON.parse(seed);
+    if (parsed && Array.isArray(parsed.addresses)) {
+      connectedAccount = parsed;
+      cachedNetwork = parsed.network || null;
+    }
+  }
+} catch (e) {
+  // ignore a malformed seed
+}
+
+// Persist (conn) or clear (null) the approved connection for this origin. The
+// content script owns chrome.storage; the page world just notifies it.
+function persistConnection(conn) {
+  connectedAccount = conn;
+  cachedNetwork = conn && conn.network ? conn.network : null;
+  document.dispatchEvent(
+    new CustomEvent("horizon-provider-persist", { detail: conn }),
+  );
+}
+
+function ok(id, result) {
+  return { jsonrpc: "2.0", id, result };
+}
+function rpcErr(id, code, message, data) {
+  const error = { code, message };
+  if (data !== undefined) error.data = data;
+  return { jsonrpc: "2.0", id, error };
+}
+
+// Normalise a house rejection (which may carry `.error` as a string from a
+// user-rejection, or an object from a validation failure) or a raw JS throw
+// into a sats-connect error envelope.
+function toError(id, e) {
+  // Default to INTERNAL: a raw JS throw or a failure with no structured error
+  // is a wallet/transport problem, not a user cancellation. The house side
+  // sends a plain-string `.error` only for explicit user rejections, so that
+  // (and only that) maps to USER_REJECTION below.
+  let code = RPC_ERROR.INTERNAL;
+  let message = "Horizon Wallet request failed";
+  let data;
+  if (e && typeof e === "object" && e.error != null) {
+    const he = e.error;
+    if (typeof he === "string") {
+      code = RPC_ERROR.USER_REJECTION;
+      message = he;
+    } else if (typeof he === "object") {
+      if (typeof he.code === "number") code = he.code;
+      if (he.message) message = he.message;
+      data = he.data;
+    }
+  } else if (e && e.message) {
+    message = e.message;
+  }
+  return rpcErr(id, code, message, data);
+}
+
+function base64ToHex(b64) {
+  const bin = atob(b64);
+  let out = "";
+  for (let i = 0; i < bin.length; i++) {
+    out += bin.charCodeAt(i).toString(16).padStart(2, "0");
+  }
+  return out;
+}
+function hexToBase64(hexStr) {
+  let bin = "";
+  for (let i = 0; i < hexStr.length; i += 2) {
+    bin += String.fromCharCode(parseInt(hexStr.substr(i, 2), 16));
+  }
+  return btoa(bin);
+}
+
+// Horizon derives addresses by script type; sats-connect groups them by
+// purpose. Map taproot -> ordinals, everything else -> payment (the Xverse
+// convention), then keep only the purposes the dApp asked for.
+function purposeForType(type) {
+  return type === "p2tr" ? "ordinals" : "payment";
+}
+function mapAddresses(houseAddresses) {
+  return (houseAddresses || []).map((a) => ({
+    address: a.address,
+    publicKey: a.publicKey,
+    addressType: a.type,
+    purpose: purposeForType(a.type),
+    walletType: "software",
+  }));
+}
+// Keep only the purposes the dApp asked for (null/empty -> all).
+function filterPurposes(mapped, purposes) {
+  const wanted =
+    Array.isArray(purposes) && purposes.length ? new Set(purposes) : null;
+  return wanted ? mapped.filter((a) => wanted.has(a.purpose)) : mapped;
+}
+function networkObject(name) {
+  const bitcoin = BITCOIN_NETWORK[name] || "Mainnet";
+  const isMain = bitcoin === "Mainnet";
+  return {
+    bitcoin: { name: bitcoin },
+    stacks: { name: isMain ? "mainnet" : "testnet" },
+    spark: { name: isMain ? "mainnet" : "regtest" },
+  };
+}
+
+// Drives the house getAddresses popup (user approves), reshapes + persists the
+// full account, and returns the purpose-filtered view the caller asked for.
+async function fetchAccounts(purposes) {
+  const { result } = await houseTransport("getAddresses", undefined);
+  const all = mapAddresses(result.addresses);
+  persistConnection({ addresses: all, network: result.network });
+  return {
+    addresses: filterPurposes(all, purposes),
+    network: result.network,
+  };
+}
+
+async function handleSatsConnect(method, params) {
+  const id = crypto.randomUUID();
+  const p = params || {};
+  try {
+    switch (method) {
+      case "getAccounts": {
+        // Legacy connect: a flat address array.
+        const { addresses } = await fetchAccounts(p.purposes);
+        return ok(id, addresses);
+      }
+      case "getAddresses": {
+        const { addresses, network } = await fetchAccounts(p.purposes);
+        return ok(id, { addresses, network: networkObject(network) });
+      }
+      case "wallet_connect": {
+        // Connect is an explicit user action: prompt and (re)establish account.
+        const { addresses, network } = await fetchAccounts(p.addresses);
+        return ok(id, {
+          id: crypto.randomUUID(),
+          addresses,
+          walletType: "software",
+          network: networkObject(network),
+        });
+      }
+      case "wallet_getAccount": {
+        // Return the already-connected account silently (no popup). Only prompt
+        // if this origin has never connected.
+        let conn = connectedAccount;
+        if (!conn) {
+          await fetchAccounts(undefined);
+          conn = connectedAccount;
+        }
+        return ok(id, {
+          id: crypto.randomUUID(),
+          addresses: filterPurposes(conn.addresses, p.addresses),
+          walletType: "software",
+          network: networkObject(conn.network),
+        });
+      }
+      case "wallet_disconnect":
+        persistConnection(null);
+        return ok(id, null);
+      case "getInfo":
+        return ok(id, {
+          version: WALLET_VERSION,
+          platform: "web",
+          methods: SATS_CONNECT_METHODS,
+          supports: [],
+        });
+      case "wallet_getNetwork":
+      case "getNetwork": {
+        if (!cachedNetwork) {
+          return rpcErr(
+            id,
+            RPC_ERROR.ACCESS_DENIED,
+            "Network unknown — call wallet_connect / getAddresses first",
+          );
+        }
+        return ok(id, networkObject(cachedNetwork));
+      }
+      case "signPsbt": {
+        if (p.broadcast) {
+          return rpcErr(
+            id,
+            RPC_ERROR.METHOD_NOT_SUPPORTED,
+            "Horizon Wallet does not broadcast from signPsbt; set broadcast:false",
+          );
+        }
+        if (typeof p.psbt !== "string") {
+          return rpcErr(
+            id,
+            RPC_ERROR.INVALID_PARAMS,
+            "Missing 'psbt' (base64) parameter for signPsbt",
+          );
+        }
+        const houseParams = {
+          hex: base64ToHex(p.psbt),
+          signInputs: p.signInputs || {},
+          // The house side treats this as a whitelist of permitted sighash
+          // types (bitcoinjs `signInput` allowedSighashTypes). Allow both
+          // SIGHASH_DEFAULT (0x00, taproot) and SIGHASH_ALL (0x01, the default
+          // for segwit-v0/legacy inputs) so mixed-input PSBTs sign; without
+          // 0x01 any non-taproot input throws "Sighash type is not allowed".
+          sighashTypes: [
+            ...new Set([
+              0x00,
+              0x01,
+              ...(p.allowedSignHash != null ? [p.allowedSignHash] : []),
+            ]),
+          ],
+        };
+        const { result } = await houseTransport("signPsbt", houseParams);
+        return ok(id, { psbt: hexToBase64(result.hex) });
+      }
+      case "sendTransfer": {
+        const recipients = Array.isArray(p.recipients) ? p.recipients : [];
+        if (recipients.length !== 1) {
+          return rpcErr(
+            id,
+            RPC_ERROR.INVALID_PARAMS,
+            "Horizon Wallet supports exactly one recipient per sendTransfer",
+          );
+        }
+        const r = recipients[0] || {};
+        const amount =
+          typeof r.amount === "number" ? r.amount : parseInt(r.amount, 10);
+        if (!r.address || !Number.isFinite(amount) || amount <= 0) {
+          return rpcErr(
+            id,
+            RPC_ERROR.INVALID_PARAMS,
+            "sendTransfer recipient requires an address and a positive amount (sats)",
+          );
+        }
+        const { result } = await houseTransport("sendTransfer", {
+          destination: r.address,
+          amount: Math.trunc(amount),
+        });
+        return ok(id, { txid: result.txid });
+      }
+      case "getBalance": {
+        const { result } = await houseTransport("getBalance", {});
+        return ok(id, {
+          confirmed: String(result.confirmed),
+          unconfirmed: String(result.unconfirmed),
+          total: String(result.total),
+        });
+      }
+      default:
+        return rpcErr(id, RPC_ERROR.METHOD_NOT_FOUND, `Unknown method: ${method}`);
+    }
+  } catch (e) {
+    return toError(id, e);
+  }
+}
+
+// signMessage's house and sats-connect params overlap ({message,address}), so —
+// unlike every other method — it can't be disambiguated by shape. We therefore
+// give it a single JSON-RPC-correct behaviour for both worlds: success AND error
+// are always *resolved* as a JSON-RPC envelope, never rejected. House callers
+// still read res.result.signature on success and now read res.error on failure
+// (the Horizon Wallet house adapters were updated to match). Resolving is
+// required for sats-connect: its core lets a provider rejection propagate as a
+// thrown exception instead of a { status: 'error' } result.
+async function handleSignMessage(params) {
+  const id = crypto.randomUUID();
+  const p = params || {};
+  if (p.protocol && String(p.protocol).toUpperCase() === "BIP322") {
+    return rpcErr(
+      id,
+      RPC_ERROR.METHOD_NOT_SUPPORTED,
+      "Horizon Wallet signs messages with ECDSA (BIP-137); BIP322 is not supported",
+    );
+  }
+  try {
+    const { result } = await houseTransport("signMessage", {
+      message: p.message,
+      address: p.address,
+    });
+    return ok(id, {
+      signature: result.signature,
+      messageHash: result.messageHash,
+      address: result.address || p.address,
+      protocol: "ECDSA",
+    });
+  } catch (e) {
+    return toError(id, e);
+  }
+}
+
+function isSatsConnectCall(method, params) {
+  switch (method) {
+    case "getAccounts":
+    case "wallet_connect":
+    case "wallet_getAccount":
+    case "wallet_disconnect":
+    case "wallet_getNetwork":
+    case "getNetwork":
+    case "getInfo":
+    case "sendTransfer":
+    case "getBalance":
+      return true;
+    case "getAddresses":
+      return !!(params && params.purposes);
+    case "signPsbt":
+      return !!(params && typeof params.psbt === "string");
+    default:
+      return false;
+  }
+}
+
 const provider = {
   request: (method, params) => {
-    const id = crypto.randomUUID();
-    const rpcRequest = {
-      jsonrpc: "2.0",
-      id,
-      method,
-      params,
-    };
-    document.dispatchEvent(new CustomEvent("horizon-provider-request", { detail: rpcRequest }));
-    return new Promise((resolve, reject) => {
-      function handleMessage(event) {
-        const response = event.data;
-        if (response.id != id) return;
-        window.removeEventListener("message", handleMessage);
-        if ("error" in response) return reject(response);
-        return resolve({ result: response });
-      }
-      window.addEventListener("message", handleMessage);
-    });
+    if (method === "signMessage") return handleSignMessage(params);
+    if (isSatsConnectCall(method, params)) {
+      return handleSatsConnect(method, params);
+    }
+    return houseTransport(method, params);
   },
 };
 

--- a/web/horizon-provider.js
+++ b/web/horizon-provider.js
@@ -211,7 +211,15 @@ function filterPurposes(mapped, purposes) {
   return wanted ? mapped.filter((a) => wanted.has(a.purpose)) : mapped;
 }
 function networkObject(name) {
-  const bitcoin = BITCOIN_NETWORK[name] || "Mainnet";
+  const bitcoin = BITCOIN_NETWORK[name];
+  // Never silently coerce an unknown network to Mainnet: telling a dApp it is
+  // on Mainnet when the wallet is on a test network (or the reverse) would let
+  // it build/sign against the wrong chain. Surface it instead — every caller
+  // runs inside handleSatsConnect's try/catch, so this becomes a JSON-RPC
+  // internal error rather than a false network.
+  if (!bitcoin) {
+    throw new Error(`Unsupported wallet network: ${name}`);
+  }
   const isMain = bitcoin === "Mainnet";
   return {
     bitcoin: { name: bitcoin },

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -3,7 +3,8 @@
   "description": "A wallet for Bitcoin metaprotocols — assets, NFTs, fair mints, and the apps built on them. Counterparty, Ordinals, Kontor.",
   "version": "2.3.1",
   "permissions": [
-    "tabs"
+    "tabs",
+    "storage"
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"


### PR DESCRIPTION
## sats-connect support

Adds a [sats-connect](https://docs.xverse.app/sats-connect) compatibility layer so third-party Bitcoin dApps (Xverse / WBIP convention) can talk to Horizon Wallet, plus two new wallet RPCs (`getBalance`, `sendTransfer`).

The translation between the sats-connect protocol and the wallet's existing "house" RPC happens **entirely in the page-world provider** (`web/horizon-provider.js`); the content-script / background / Dart code is only *extended* with the two genuinely new actions — the existing house API keeps working byte-for-byte.

### How it works

- **Compatibility layer (`horizon-provider.js`).** `provider.request(method, params)` now dispatches per method/shape:
  - sats-connect methods (`getAccounts`, `getAddresses` w/ `purposes`, `wallet_connect`, `wallet_getAccount`, `wallet_disconnect`, `getNetwork`/`wallet_getNetwork`, `getInfo`, `signPsbt` w/ base64 `psbt`, `signMessage`, `sendTransfer`, `getBalance`) are translated onto the house RPC and returned as JSON-RPC 2.0 envelopes (errors are *resolved*, not thrown, as the spec requires);
  - everything else falls through to the unchanged house transport.
  - Address shapes are mapped to sats-connect *purposes* (`p2tr → ordinals`, else `payment`), networks to `BitcoinNetworkType`, and PSBTs are round-tripped hex↔base64.
- **Silent reconnect.** The approved connection (addresses + network) is cached in `chrome.storage.local`, keyed strictly by origin, and seeded back into the page-world provider via the injected script's dataset, so `wallet_getAccount` / `getNetwork` answer without a popup across reloads. Writes are serialized through a single promise chain to avoid read-modify-write clobbering.
- **`getBalance`** — read-only Esplora lookup for the wallet's payment (native-segwit) address; auto-resolves with confirmed/unconfirmed/total sats (no approval prompt).
- **`sendTransfer`** — single-recipient BTC send composed from the payment address; the user reviews the wallet-picked (medium) fee, then signs & broadcasts.

### New wallet plumbing

- `RPCGetBalanceAction` / `RPCSendTransferAction` entities + parsing in `ActionRepositoryImpl` (with field-count and positive-amount validation).
- `GetBalanceBloc` / `SendTransferBloc` + forms, and `/rpc/get-balance` & `/rpc/send-transfer` routes.
- Success **and** error callbacks wired through `setup.dart`: a fatal failure now returns a real JSON-RPC error (`-32603`) to the dApp and closes the popup, instead of hanging until the user closes the window (which the background otherwise misreports as a user rejection).

### Robustness fixes folded in

- `sendTransfer` double-broadcast guarded two ways: a `ConfirmSend` re-entrancy guard in the bloc and disabling the confirm/password inputs once a broadcast is in flight.
- Failure split into `composeFailure` (fatal → error to dApp + close) vs `broadcastFailure` (retryable → popup stays open).
- `listenForPopupClose` now detaches its `chrome.windows.onRemoved` handler on close (was leaking a permanent listener per RPC call) and no-ops when the popup failed to open.
- Replaced the unmaintained `lucide_icons` with `lucide_icons_flutter` to fix the web build on Flutter 3.44+.
- `storage` permission added to the manifest; provider icon/version metadata fixed.

### UI polish

- Trimmed the opaque-PSBT (`signPsbt`) sign notice from three sentences to one so the approval popup no longer scrolls.

### Tests

- `action_repository_impl_test.dart`: encode/decode + validation for both new actions.
- `send_transfer_bloc_test.dart`: ConfirmSend re-entrancy (broadcast fires exactly once on double-confirm / late re-tap) and compose-vs-broadcast failure classification.
